### PR TITLE
Give PEAR it's own ensure.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,12 +44,13 @@
 # See LICENSE file
 #
 class php (
-  $ensure         = 'latest',
+  $ensure         = $php::params::ensure,
   $manage_repos   = $php::params::manage_repos,
   $fpm            = true,
   $dev            = true,
   $composer       = true,
   $pear           = true,
+  $pear_ensure    = $php::params::pear_ensure,
   $phpunit        = false,
   $extensions     = {},
   $settings       = {},
@@ -62,6 +63,7 @@ class php (
   validate_bool($dev)
   validate_bool($composer)
   validate_bool($pear)
+  validate_string($pear_ensure)
   validate_bool($phpunit)
   validate_hash($extensions)
   validate_hash($settings)
@@ -97,7 +99,9 @@ class php (
   }
   if $pear {
     Anchor['php::begin'] ->
-      class { 'php::pear': } ->
+      class { 'php::pear':
+        ensure => $pear_ensure,
+      } ->
     Anchor['php::end']
   }
   if $phpunit {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,10 +13,12 @@
 #
 class php::params {
 
+  $ensure              = 'latest'
   $fpm_service_enable  = true
   $composer_source     = 'https://getcomposer.org/composer.phar'
   $composer_path       = '/usr/local/bin/composer'
   $composer_max_age    = 30
+  $pear_ensure         = 'latest'
   $pear_package_suffix = 'pear'
   $phpunit_source    = 'https://phar.phpunit.de/phpunit.phar'
   $phpunit_path      = '/usr/local/bin/phpunit'

--- a/manifests/pear.pp
+++ b/manifests/pear.pp
@@ -20,7 +20,7 @@
 # See LICENSE file
 #
 class php::pear (
-  $ensure  = $php::ensure,
+  $ensure  = $php::pear_ensure,
   $package = undef,
 ) inherits php::params {
 


### PR DESCRIPTION
php::pear currently defaults to ensure "$php::ensure". This causes some
trouble once versions are specified as PHP could be on 5.6 and PEAR at 1.9.