### PR TITLE
Use the extension 'source' parameter for all providers

### DIFF
--- a/manifests/extension.pp
+++ b/manifests/extension.pp
@@ -43,7 +43,7 @@
 define php::extension(
   $ensure            = 'installed',
   $provider          = undef,
-  $pecl_source       = undef,
+  $source            = undef,
   $package_prefix    = $php::package_prefix,
   $header_packages   = [],
   $compiler_packages = $php::params::compiler_packages,
@@ -74,7 +74,7 @@ define php::extension(
         ensure   => $ensure,
         name     => $title,
         provider => $provider,
-        source   => $pecl_source,
+        source   => $source,
         require  => [
           Class['php::pear'],
           Class['php::dev'],
@@ -88,6 +88,7 @@ define php::extension(
       package { $real_package:
         ensure   => $ensure,
         provider => $provider,
+        source   => $source,
       }
     }
   }

--- a/manifests/extension.pp
+++ b/manifests/extension.pp
@@ -16,8 +16,13 @@
 #   Could be "pecl", "apt", "dpkg" or any other OS package provider
 #   If set to "none", no package will be installed
 #
+# [*source*]
+#   The source to install the extension from. Possible values
+#   depend on the *provider* used
+#
 # [*pecl_source*]
 #   The pecl source channel to install pecl package from
+#   Superseded by *source*
 #
 # [*header_packages*]
 #   System packages dependecies to install for extensions (e.g. for
@@ -44,6 +49,7 @@ define php::extension(
   $ensure            = 'installed',
   $provider          = undef,
   $source            = undef,
+  $pecl_source       = undef,
   $package_prefix    = $php::package_prefix,
   $header_packages   = [],
   $compiler_packages = $php::params::compiler_packages,
@@ -60,6 +66,17 @@ define php::extension(
   validate_array($header_packages)
   validate_bool($zend)
 
+  if $source and $pecl_source {
+    fail('Only one of $source and $pecl_source can be specified.')
+  }
+
+  if $source {
+    $real_source = $source
+  }
+  else {
+    $real_source = $pecl_source
+  }
+
   if $provider != 'none' {
     $real_package = $provider ? {
       'pecl'  => "pecl-${title}",
@@ -74,7 +91,7 @@ define php::extension(
         ensure   => $ensure,
         name     => $title,
         provider => $provider,
-        source   => $source,
+        source   => $real_source,
         require  => [
           Class['php::pear'],
           Class['php::dev'],
@@ -88,7 +105,7 @@ define php::extension(
       package { $real_package:
         ensure   => $ensure,
         provider => $provider,
-        source   => $source,
+        source   => $real_source,
       }
     }
   }


### PR DESCRIPTION
Previously, only pecl provider was using the parameter pecl_source
which was a shame since pear provider also understands the source
parameter. This renames 'pecl_source' to 'source' and supplies it
to all providers.

Unfortunately this introduces an API change - not sure how to handle backwards compatibility. It would be possible to understand both source and pecl_source but it sounds quite hacky.

What do you think?