### PR TITLE
add support for FreeBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 
 mayflower/php is a Puppet module for managing PHP with a strong focus
 on php-fpm. We strive to support all recent versions of Debian, Ubuntu,
-RedHat/CentOS and openSuSE/SLES. Managing Apache with `mod_php` is not
-supported.
+RedHat/CentOS, openSUSE/SLES and FreeBSD. Managing Apache with `mod_php`
+is not supported.
 
 This originally was a fork of [jippi/puppet-php](https://github.com/jippi/puppet-php)
 (nodes-php on Puppet Forge) but has since been rewritten in large parts.
@@ -106,6 +106,14 @@ Apache with `mod_php` is not supported by this module. Please use
 We prefer using php-fpm. You can find an example Apache vhost in
 `manifests/apache_vhost.pp` that shows you how to use `mod_proxy_fcgi` to
 connect to php-fpm.
+
+### FreeBSD support
+
+On FreeBSD systems we purge the system-wide `extensions.ini` in favour of
+per-module configuration files.
+
+Please also note that support for Composer and PHPUnit on FreeBSD is untested
+and thus likely incomplete.
 
 ## Bugs & New Features
 

--- a/manifests/composer.pp
+++ b/manifests/composer.pp
@@ -19,6 +19,7 @@ class php::composer (
   $path        = $php::params::composer_path,
   $auto_update = true,
   $max_age     = $php::params::composer_max_age,
+  $root_group  = $php::params::root_group,
 ) inherits php::params {
 
   if $caller_module_name != $module_name {
@@ -30,16 +31,19 @@ class php::composer (
   validate_bool($auto_update)
   validate_re("x${max_age}", '^x\d+$')
 
+  ensure_packages(['wget'])
+
   exec { 'download composer':
     command => "wget ${source} -O ${path}",
     creates => $path,
-    path    => ['/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/'],
-    require => Class['php::cli'],
+    path    => ['/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/',
+                '/usr/local/bin', '/usr/local/sbin'],
+    require => [Class['php::cli'],Package['wget']],
   } ->
   file { $path:
     mode  => '0555',
     owner => root,
-    group => root,
+    group => $root_group,
   }
 
   if $auto_update {

--- a/manifests/dev.pp
+++ b/manifests/dev.pp
@@ -13,7 +13,6 @@ class php::dev(
   $package = "${php::package_prefix}${php::params::dev_package_suffix}",
 ) inherits php::params {
 
-
   if $caller_module_name != $module_name {
     warning('php::dev is private')
   }
@@ -21,7 +20,13 @@ class php::dev(
   validate_string($ensure)
   validate_string($package)
 
-  package { $package:
+  # On FreeBSD there is no 'devel' package.
+  $real_package = $::osfamily ? {
+    'FreeBSD' => [],
+    default   => $package,
+  }
+
+  package { $real_package:
     ensure  => $ensure,
     require => Class['php::packages'],
   }

--- a/manifests/extension.pp
+++ b/manifests/extension.pp
@@ -23,7 +23,7 @@
 #   Superseded by *source*
 #
 # [*header_packages*]
-#   System packages dependecies to install for extensions (e.g. for
+#   System packages dependencies to install for extensions (e.g. for
 #   memcached libmemcached-dev on debian)
 #
 # [*zend*]
@@ -108,10 +108,21 @@ define php::extension(
   }
 
   $lowercase_title = downcase($title)
-  $real_settings = $provider ? {
-    'pecl'  => deep_merge({ "${extension_key}" => "${name}.so" }, $settings),
-    default => $settings
+
+  if $provider == 'pecl' {
+    $real_settings = deep_merge({"${extension_key}"=>"${name}.so"},$settings)
   }
+  else {
+    # On FreeBSD systems the settings file is required for every module
+    # (regardless of provider) to allow for proper module management.
+    if $::osfamily == 'FreeBSD' {
+      $real_settings = deep_merge({"${extension_key}"=>"${name}.so"},$settings)
+    }
+    else {
+      $real_settings = $settings
+    }
+  }
+
   $php_settings_file = "${php::params::config_root_ini}/${lowercase_title}.ini"
 
   php::config { $title:

--- a/manifests/fpm.pp
+++ b/manifests/fpm.pp
@@ -28,8 +28,15 @@ class php::fpm (
 
   $real_settings = deep_merge($settings, hiera_hash('php::fpm::settings', {}))
 
+  # On FreeBSD fpm is not a separate package, but included in the 'php' package.
+  # Implies that the option SET+=FPM was set when building the port.
+  $real_package = $::osfamily ? {
+    'FreeBSD' => [],
+    default   => $package,
+  }
+
   anchor { 'php::fpm::begin': } ->
-    package { $package:
+    package { $real_package:
       ensure  => $ensure,
       require => Class['php::packages'],
     } ->

--- a/manifests/fpm/config.pp
+++ b/manifests/fpm/config.pp
@@ -60,6 +60,7 @@ class php::fpm::config(
   $log_owner                   = $php::params::fpm_user,
   $log_group                   = $php::params::fpm_group,
   $log_dir_mode                = '0770',
+  $root_group                  = $php::params::root_group,
 ) inherits php::params {
 
   validate_string($user)
@@ -95,14 +96,14 @@ class php::fpm::config(
     notify  => Class['php::fpm::service'],
     content => template('php/fpm/php-fpm.conf.erb'),
     owner   => root,
-    group   => root,
+    group   => $root_group,
     mode    => '0644',
   }
 
   file { $pool_base_dir:
     ensure => directory,
     owner  => root,
-    group  => root,
+    group  => $root_group,
     mode   => '0755',
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -111,4 +111,14 @@ class php (
     require => Class['php::cli'],
     before  => Anchor['php::end']
   })
+
+  # On FreeBSD purge the system-wide extensions.ini. It is going
+  # to be replaced with per-module configuration files.
+  if $::osfamily == 'FreeBSD' {
+    # Purge the system-wide extensions.ini
+    file { '/usr/local/etc/php/extensions.ini':
+      ensure  => absent,
+      require => Class['php::packages'],
+    }
+  }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -31,6 +31,7 @@ class php::params {
       $package_prefix          = 'php5-'
       $compiler_packages       = 'build-essential'
       $manage_repos            = true
+      $root_group              = 'root'
     }
     'Suse': {
       $config_root             = '/etc/php5'
@@ -48,6 +49,7 @@ class php::params {
       $fpm_group               = 'www'
       $package_prefix          = 'php5-'
       $manage_repos            = true
+      $root_group              = 'root'
       case $::operatingsystem {
         'SLES': {
           $compiler_packages = []
@@ -76,6 +78,29 @@ class php::params {
       $package_prefix          = 'php-'
       $compiler_packages       = ['gcc', 'gcc-c++', 'make']
       $manage_repos            = false
+      $root_group              = 'root'
+    }
+    'FreeBSD': {
+      $config_root             = '/usr/local/etc'
+      $config_root_ini         = "${config_root}/php"
+      # No common packages, because the required PHP base package will be
+      # pulled in as a dependency. This preserves the ability to choose
+      # any available PHP version by setting the 'package_prefix' parameter.
+      $common_package_names    = []
+      $common_package_suffixes = ['extensions']
+      $cli_inifile             = "${config_root}/php-cli.ini"
+      $dev_package_suffix      = ''
+      $fpm_config_file         = "${config_root}/php-fpm.conf"
+      $fpm_inifile             = "${config_root}/php.ini"
+      $fpm_package_suffix      = ''
+      $fpm_pool_dir            = "${config_root}/php-fpm.d"
+      $fpm_service_name        = 'php-fpm'
+      $fpm_user                = 'www'
+      $fpm_group               = 'www'
+      $package_prefix          = 'php56-'
+      $compiler_packages       = ['gcc']
+      $manage_repos            = false
+      $root_group              = 'wheel'
     }
     default: {
       fail("Unsupported osfamily: ${::osfamily}")

--- a/manifests/pear.pp
+++ b/manifests/pear.pp
@@ -23,6 +23,9 @@ class php::pear (
       # Debian is a litte stupid: The pear package is called 'php-pear'
       # even though others are called 'php5-fpm' or 'php5-dev'
       $package_name = "php-${php::params::pear_package_suffix}"
+    } elsif $::osfamily == 'FreeBSD' {
+      # On FreeBSD the package name is just 'pear'.
+      $package_name = $php::params::pear_package_suffix
     } else {
       # This is the default for all other architectures
       $package_name =
@@ -43,7 +46,8 @@ class php::pear (
   exec { 'php::pear::auto_discover':
     command => 'pear config-set auto_discover 1 system',
     unless  => 'pear config-get auto_discover system | grep -q 1',
-    path    => ['/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/'],
+    path    => ['/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/',
+                '/usr/local/bin', '/usr/local/sbin'],
     require => Package[$package_name],
   }
 }

--- a/manifests/phpunit.pp
+++ b/manifests/phpunit.pp
@@ -30,11 +30,13 @@ class php::phpunit (
   validate_bool($auto_update)
   validate_re("x${max_age}", '^x\d+$')
 
+  ensure_packages(['wget'])
+
   exec { 'download phpunit':
     command => "wget ${source} -O ${path}",
     creates => $path,
     path    => ['/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/'],
-    require => Class['php::cli'],
+    require => [Class['php::cli'],Package['wget']],
   } ->
   file { $path:
     mode  => '0555',

--- a/metadata.json
+++ b/metadata.json
@@ -24,6 +24,7 @@
     { "operatingsystem": "Debian" },
     { "operatingsystem": "RedHat" },
     { "operatingsystem": "CentOS" },
+    { "operatingsystem": "FreeBSD" },
     { "operatingsystem": "SLES" }
   ]
 }

--- a/templates/fpm/php-fpm.conf.erb
+++ b/templates/fpm/php-fpm.conf.erb
@@ -22,10 +22,12 @@
 ; Pid file
 ; Note: the default prefix is /var
 ; Default Value: none
-<% if @osfamily != "RedHat" %>
-pid = /var/run/php5-fpm.pid
-<% else %>
+<% if @osfamily == "FreeBSD" %>
+pid = /var/run/php-fpm.pid
+<% elsif @osfamily == "RedHat" %>
 pid = /var/run/php-fpm/php-fpm.pid
+<% else %>
+pid = /var/run/php5-fpm.pid
 <% end %>
 
 ; Error log file
@@ -33,10 +35,12 @@ pid = /var/run/php-fpm/php-fpm.pid
 ; in a local file.
 ; Note: the default prefix is /var
 ; Default Value: log/php-fpm.log
-<% if @osfamily != "RedHat" %>
-error_log = /var/log/php5-fpm.log
-<% else %>
+<% if @osfamily == "FreeBSD" %>
+error_log = /var/log/php-fpm.log
+<% elsif @osfamily == "RedHat" %>
 error_log = /var/log/php-fpm/error.log
+<% else %>
+error_log = /var/log/php5-fpm.log
 <% end %>
 
 ; syslog_facility is used to specify what type of program is logging the


### PR DESCRIPTION
This adds support for FreeBSD and handles the following differences:

* no 'fpm' package available (included in main PHP package)
* no 'devel' package available (also included in main PHP package)
* group 'root' is named 'wheel' on FreeBSD
* additional software is installed under '/usr/local'
* replace FreeBSD's system-wide `extensions.ini` with per-module configuration files

There are a few limitations though:

* no support for `manage_repos` on FreeBSD (not useful on this plattform)
* support for 'composer' and 'phpunit' is untested

Tested with the following hiera configuration:

```yaml
php::ensure: 'installed'
php::manage_repos: false
php::fpm: true
php::dev: true
php::composer: false
php::pear: true
php::phpunit: false
php::fpm::config:log_level: 'notice'
php::composer::auto_update: true
php::settings:
  Date/date.timezone: 'Europe/Berlin'
php::cli::settings:
  PHP/memory_limit: '256M'
php::fpm::settings:
  PHP/short_open_tag: 'On'
php::fpm::service::ensure: 'stopped'
php::fpm::service::enable: false
php::package_prefix: 'php55-'
php::extensions:
  bcmath: {}
  xml: {}
  mysql: {}
```
