### PR TITLE
Re-adding support for PHP < 5.4 (eg, Ubuntu 12) without breaking 5.4+

### DIFF
--- a/lib/facter/php_version.rb
+++ b/lib/facter/php_version.rb
@@ -1,0 +1,11 @@
+Facter.add(:php_version) do
+  confine :kernel => :linux
+  setcode do
+    version = Facter::Util::Resolution.exec("/usr/bin/env php -r 'echo PHP_VERSION;' 2>/dev/null")
+    if version
+      version.match(/(\d+\.\d+\.\d+)/).to_s
+    else
+      nil
+    end
+  end
+end

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -27,7 +27,11 @@ class php::params {
   case $::osfamily {
     'Debian': {
       $config_root             = '/etc/php5'
-      $config_root_ini         = "${::php::params::config_root}/mods-available"
+      if $::php_version == '' or versioncmp($::php_version, '5.4') >= 0 {
+        $config_root_ini       = "${::php::params::config_root}/mods-available"
+      } else {
+        $config_root_ini       = "${::php::params::config_root}/conf.d"
+      }
       $common_package_names    = []
       $common_package_suffixes = ['cli', 'common']
       $cli_inifile             = "${config_root}/cli/php.ini"

--- a/spec/defines/extension_spec.rb
+++ b/spec/defines/extension_spec.rb
@@ -75,9 +75,80 @@ describe 'php::extension' do
     }
   end
 
-  context 'on Debian' do
+  context 'with an undetermined php version' do
     let(:facts) { {
       :osfamily    => 'Debian',
+      :php_version => ''
+    } }
+    let(:title) { 'xdebug' }
+
+    it {
+      should contain_php__config('xdebug').with({
+        :file => '/etc/php5/mods-available/xdebug.ini',
+      })
+    }
+  end
+
+  context 'with php 5.3' do
+    let(:facts) { {
+      :osfamily    => 'Debian',
+      :php_version => '5.3'
+    } }
+    let(:title) { 'xdebug' }
+
+    it {
+      should contain_php__config('xdebug').with({
+        :file => '/etc/php5/conf.d/xdebug.ini',
+      })
+    }
+  end
+
+  context 'with php 5.4' do
+    let(:facts) { {
+      :osfamily    => 'Debian',
+      :php_version => '5.4'
+    } }
+    let(:title) { 'xdebug' }
+
+    it {
+      should contain_php__config('xdebug').with({
+        :file => '/etc/php5/mods-available/xdebug.ini',
+      })
+    }
+  end
+
+  context 'with php 5.4.1' do
+    let(:facts) { {
+      :osfamily    => 'Debian',
+      :php_version => '5.4.1'
+    } }
+    let(:title) { 'xdebug' }
+
+    it {
+      should contain_php__config('xdebug').with({
+        :file => '/etc/php5/mods-available/xdebug.ini',
+      })
+    }
+  end
+
+  context 'with php 5.5' do
+    let(:facts) { {
+      :osfamily    => 'Debian',
+      :php_version => '5.5'
+    } }
+    let(:title) { 'xdebug' }
+
+    it {
+      should contain_php__config('xdebug').with({
+        :file => '/etc/php5/mods-available/xdebug.ini',
+      })
+    }
+  end
+
+  context 'with php 5.5.11-1~dotdeb.1' do
+    let(:facts) { {
+      :osfamily    => 'Debian',
+      :php_version => '5.5.11-1~dotdeb.1'
     } }
     let(:title) { 'xdebug' }
 


### PR DESCRIPTION
We're still running some Ubuntu 12.04 systems and need support for both PHP 5.3 and 5.4+ from puppet-php.  These changes seems to do the trick.