### PR TITLE
Generate & serve documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,34 @@
 language: ruby
 rvm:
-  - 2.1.5
-  - 2.0.0
-  - 1.9.3
+- 2.1.5
+- 2.0.0
+- 1.9.3
 env:
+  matrix:
   - PUPPET_VERSION=3.4.3
   - PUPPET_VERSION=3.6.2
   - PUPPET_VERSION=3.7.3
+  global:
+  - secure: Zc0V6JqwpFTTtVE7jVFg5R6UgXZrzsBGa6ckbOnIHPCOyJsV4oWO6RxKsYI+ozzD9nrEdrT/DTcHKRz84YqrMXxvBU9HA4S/ZrNQoRiH3bEnI3UHC6jQJRX0c71gaJEMQ3S33my39vLD7EsealX3p+j8asL8e8glYR1am9ekUB8=
+matrix:
+  exclude:
+  - rvm: 2.1.5
+    env: PUPPET_VERSION=3.7.3
+  include:
+  - rvm: 2.1.5
+    env: PUPPET_VERSION=3.7.3 DOCS=true
+after_success: |
+  [ $TRAVIS_BRANCH = master ] &&
+  [ $TRAVIS_PULL_REQUEST = false ] &&
+  [ -n "$DOCS" ] &&
+  puppet module install puppetlabs/strings &&
+  puppet strings &&
+  sudo pip install ghp-import &&
+  echo php.puppet.mayflower.de > doc/CNAME &&
+  ghp-import -n doc &&
+  git push -fq https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git gh-pages
 notifications:
   webhooks:
     urls:
-      - http://travis-notify.mayflower.de/opensource
+    - http://travis-notify.mayflower.de/opensource
     on_start: true

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ group :development, :test do
   gem 'beaker', :github => 'Mayflower/beaker', :branch => 'master'
   gem 'beaker-rspec'
   gem 'pry'
+  gem 'yard'
 end
 
 if facterversion = ENV['FACTER_GEM_VERSION']

--- a/lib/puppet/parser/functions/to_hash_settings.rb
+++ b/lib/puppet/parser/functions/to_hash_settings.rb
@@ -1,16 +1,17 @@
 
 module Puppet::Parser::Functions
   newfunction(:to_hash_settings, :type => :rvalue, :doc => <<-EOS
-This function converts a {key => value} hash into a nested hash and adds an id to the outer key.
+This function converts a +{key => value}+ hash into a nested hash and adds an id to the outer key.
 
 *Examples:*
 
-to_hash_settings({'a' => 1, 'b' => 2})
+  to_hash_settings({'a' => 1, 'b' => 2})
 
-Would return: {
-  'a' => {'value' => 1},
-  'b' => {'value' => 2}
-}
+Would return:
+  {
+    'a' => {'value' => 1},
+    'b' => {'value' => 2}
+  }
 EOS
   ) do |arguments|
 

--- a/manifests/apache_vhost.pp
+++ b/manifests/apache_vhost.pp
@@ -1,5 +1,3 @@
-# == Class: php::apache
-#
 # Configures an apache vhost for php
 #
 # === Parameters
@@ -18,15 +16,6 @@
 #
 # [*fastcgi_socket*]
 #   address of the fastcgi socket
-#
-# === Authors
-#
-# Christian "Jippi" Winther <jippignu@gmail.com>
-# Robin Gloster <robin.gloster@mayflower.de>
-#
-# === Copyright
-#
-# See LICENSE file
 #
 define php::apache_vhost(
   $vhost          = 'example.com',

--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -1,30 +1,12 @@
-# == Class: php::cli
-#
 # Install and configure php CLI
 #
 # === Parameters
-#
-# [*ensure*]
-#   The PHP ensure of PHP CLI to install
-#
-# [*package*]
-#   The package name for PHP CLI
-#   For debian it's php5-cli
 #
 # [*inifile*]
 #   The path to the ini php5-cli ini file
 #
 # [*settings*]
 #   Hash with nested hash of key => value to set in inifile
-#
-# === Authors
-#
-# Christian "Jippi" Winther <jippignu@gmail.com>
-# Robin Gloster <robin.gloster@mayflower.de>
-#
-# === Copyright
-#
-# See LICENSE file
 #
 class php::cli(
   $inifile  = $php::params::cli_inifile,

--- a/manifests/composer.pp
+++ b/manifests/composer.pp
@@ -1,29 +1,18 @@
-# == Class: php::composer
-#
 # Install composer package manager
 #
 # === Parameters
 #
 # [*source*]
-# Holds URL to the Composer source file
+#   Holds URL to the Composer source file
 #
 # [*path*]
-# Holds path to the Composer executable
+#   Holds path to the Composer executable
 #
 # [*auto_update*]
-# defines if composer should be auto updated
+#   Defines if composer should be auto updated
 #
 # [*max_age*]
-# defines the time in days after which an auto-update gets executed
-#
-# === Authors
-#
-# Christian "Jippi" Winther <jippignu@gmail.com>
-# Robin Gloster <robin.gloster@mayflower.de>
-#
-# === Copyright
-#
-# See LICENSE file
+#   Defines the time in days after which an auto-update gets executed
 #
 class php::composer (
   $source      = $php::params::composer_source,

--- a/manifests/composer/auto_update.pp
+++ b/manifests/composer/auto_update.pp
@@ -1,17 +1,15 @@
-# == Class: php::composer::auto_update
-#
 # Install composer package manager
 #
 # === Parameters
 #
 # [*max_age*]
-# Defines number of days after which Composer should be updated
+#   Defines number of days after which Composer should be updated
 #
 # [*source*]
-# Holds URL to the Composer source file
+#   Holds URL to the Composer source file
 #
 # [*path*]
-# Holds path to the Composer executable
+#   Holds path to the Composer executable
 #
 # === Examples
 #
@@ -19,15 +17,6 @@
 #  class { "php::composer::auto_update":
 #    "max_age" => 90
 #  }
-#
-# === Authors
-#
-# Christian "Jippi" Winther <jippignu@gmail.com>
-# Robin Gloster <robin.gloster@mayflower.de>
-#
-# === Copyright
-#
-# See LICENSE file
 #
 class php::composer::auto_update (
   $max_age,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,5 +1,3 @@
-# == Class: php::config
-#
 # Configure php.ini settings for a PHP SAPI
 #
 # === Parameters
@@ -12,20 +10,12 @@
 #
 # === Examples
 #
-# php::config { '$unique-name':
-#   file  => '$full_path_to_ini_file'
-#   config => {
-#     {'Date/date.timezone' => 'Europe/Berlin'}
+#   php::config { '$unique-name':
+#     file  => '$full_path_to_ini_file'
+#     config => {
+#       {'Date/date.timezone' => 'Europe/Berlin'}
+#     }
 #   }
-# }
-#
-# === Authors
-#
-# Robin Gloster <robin.gloster@mayflower.de>
-#
-# === Copyright
-#
-# See LICENSE file
 #
 define php::config(
   $file,

--- a/manifests/config/setting.pp
+++ b/manifests/config/setting.pp
@@ -1,8 +1,9 @@
-# == php::config::setting
-#
 # Configure php.ini settings
 #
 # === Parameters
+#
+# [*key*]
+#   The key of the value, like `ini_setting`
 #
 # [*file*]
 #   The path to ini file
@@ -12,18 +13,10 @@
 #
 # === Examples
 #
-# php::config::setting { 'Date/date.timezone':
-#   file  => '$full_path_to_ini_file'
-#   value => 'Europe/Berlin'
-# }
-#
-# === Authors
-#
-# Robin Gloster <robin.gloster@mayflower.de>
-#
-# === Copyright
-#
-# See LICENSE file
+#   php::config::setting { 'Date/date.timezone':
+#     file  => '$full_path_to_ini_file'
+#     value => 'Europe/Berlin'
+#   }
 #
 define php::config::setting(
   $key,

--- a/manifests/dev.pp
+++ b/manifests/dev.pp
@@ -1,8 +1,4 @@
-# == Class: php::dev
-#
-# PHP dev package
-#
-# Install the development headers for PHP
+# Install the development package with headers for PHP
 #
 # === Parameters
 #
@@ -11,15 +7,6 @@
 #
 # [*package*]
 #   The package name for the PHP development files
-#
-# === Authors
-#
-# Christian "Jippi" Winther <jippignu@gmail.com>
-# Robin Gloster <robin.gloster@mayflower.de>
-#
-# === Copyright
-#
-# See LICENSE file
 #
 class php::dev(
   $ensure  = $php::ensure,

--- a/manifests/extension.pp
+++ b/manifests/extension.pp
@@ -1,5 +1,3 @@
-# == Class: php::extension
-#
 # Install a PHP extension package
 #
 # === Parameters
@@ -34,16 +32,6 @@
 #
 # [*settings*]
 #   Nested hash of global config parameters for php.ini
-#
-# === Authors
-#
-# Christian "Jippi" Winther <jippignu@gmail.com>
-# Robin Gloster <robin.gloster@mayflower.de>
-# Franz Pletz <franz.pletz@mayflower.de>
-#
-# === Copyright
-#
-# See LICENSE file
 #
 define php::extension(
   $ensure            = 'installed',

--- a/manifests/fpm.pp
+++ b/manifests/fpm.pp
@@ -1,5 +1,3 @@
-# == Class: php::fpm
-#
 # Install and configure mod_php for fpm
 #
 # === Parameters
@@ -8,14 +6,7 @@
 #   Hash of php::fpm::pool resources that will be created. Defaults
 #   to a single php::fpm::pool named www with default parameters.
 #
-# === Authors
-#
-# Robin Gloster <robin.gloster@mayflower.de>
-# Franz Pletz <franz.pletz@mayflower.de>
-#
-# === Copyright
-#
-# See LICENSE file
+# FIXME
 #
 class php::fpm (
   $ensure   = $php::ensure,

--- a/manifests/fpm/config.pp
+++ b/manifests/fpm/config.pp
@@ -1,8 +1,7 @@
-# == Class: php::fpm::config
-#
-# Configure php-fpm
+# Configure php-fpm service
 #
 # === Parameters
+#
 # [*config_file*]
 #   The path to the fpm config file
 #
@@ -46,15 +45,6 @@
 # [*log_dir_mode*]
 #   The octal mode of the directory
 #
-# === Authors
-#
-# Christian "Jippi" Winther <jippignu@gmail.com>
-# Franz Pletz <franz.pletz@mayflower.de>
-#
-# === Copyright
-#
-# See LICENSE file
-
 class php::fpm::config(
   $config_file                 = $php::params::fpm_config_file,
   $user                        = $php::params::fpm_user,

--- a/manifests/fpm/pool.pp
+++ b/manifests/fpm/pool.pp
@@ -1,19 +1,8 @@
-# == Class: php::fpm::pool
-#
 # Configure fpm pools
 #
 # === Parameters
 #
-# No parameters
-#
-# === Authors
-#
-# Christian "Jippi" Winther <jippignu@gmail.com>
-# Robin Gloster <robin.gloster@mayflower.de>
-#
-# === Copyright
-#
-# See LICENSE file
+# FIXME
 #
 define php::fpm::pool (
   $ensure = 'present',

--- a/manifests/fpm/service.pp
+++ b/manifests/fpm/service.pp
@@ -1,6 +1,4 @@
-# == Class: php::fpm::service
-#
-# Configure fpm service
+# Mange fpm service
 #
 # === Parameters
 #
@@ -12,15 +10,6 @@
 #
 # [*enable*]
 #   Defines if the service is enabled
-#
-# === Authors
-#
-# Christian "Jippi" Winther <jippignu@gmail.com>
-# Robin Gloster <robin.gloster@mayflower.de>
-#
-# === Copyright
-#
-# See LICENSE file
 #
 class php::fpm::service(
   $service_name = $php::params::fpm_service_name,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,6 +1,5 @@
-# == Class: php
-#
-# PHP base class
+# Base class with global configuration parameters that pulls in all
+# enabled components.
 #
 # === Parameters
 #
@@ -33,15 +32,6 @@
 #   This is the prefix for constructing names of php packages. This defaults
 #   to a sensible default depending on your operating system, like 'php-' or
 #   'php5-'.
-#
-# === Authors
-#
-# Robin Gloster <robin.gloster@mayflower.de>
-# Franz Pletz <franz.pletz@mayflower.de>
-#
-# === Copyright
-#
-# See LICENSE file
 #
 class php (
   $ensure         = $php::params::ensure,

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -1,5 +1,3 @@
-# == Class: php::packages
-#
 # Install common PHP packages
 #
 # === Parameters
@@ -10,15 +8,10 @@
 # [*names*]
 #   List of the names of the package to install
 #
-# === Authors
+# [*names_to_prefix*]
+#   List of packages names that should be prefixed with the common
+#   package prefix `$php::package_prefix`
 #
-# Franz Pletz <franz.pletz@mayflower.de>
-#
-# === Copyright
-#
-# See LICENSE file
-#
-
 class php::packages (
   $ensure          = $php::ensure,
   $names_to_prefix = prefix(

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,15 +1,4 @@
-# == Class: php::params
-#
 # PHP params class
-#
-# === Authors
-#
-# Christian "Jippi" Winther <jippignu@gmail.com>
-# Robin Gloster <robin.gloster@mayflower.de>
-#
-# === Copyright
-#
-# See LICENSE file
 #
 class php::params {
 

--- a/manifests/pear.pp
+++ b/manifests/pear.pp
@@ -1,5 +1,3 @@
-# == Class: php::pear
-#
 # Install PEAR package manager
 #
 # === Parameters
@@ -9,15 +7,6 @@
 #
 # [*package*]
 #   The package name for PHP pear
-#
-# === Authors
-#
-# Christian "Jippi" Winther <jippignu@gmail.com>
-# Robin Gloster <robin.gloster@mayflower.de>
-#
-# === Copyright
-#
-# See LICENSE file
 #
 class php::pear (
   $ensure  = $php::pear_ensure,

--- a/manifests/phpunit.pp
+++ b/manifests/phpunit.pp
@@ -1,30 +1,18 @@
-# == Class: php::phpunit
-#
 # Install phpunit, PHP testing framework
 #
 # === Parameters
 #
 # [*source*]
-# Holds URL to the phpunit source file
+#   Holds URL to the phpunit source file
 #
 # [*path*]
-# Holds path to the phpunit executable
+#   Holds path to the phpunit executable
 #
 # [*auto_update*]
-# defines if phpunit should be auto updated
+#   Defines if phpunit should be auto updated
 #
 # [*max_age*]
-# defines the time in days after which an auto-update gets executed
-#
-# === Authors
-#
-# Christian "Jippi" Winther <jippignu@gmail.com>
-# Tobias Nyholm <tobias@happyrecruiting.se>
-# Robin Gloster <robin.gloster@mayflower.de>
-#
-# === Copyright
-#
-# See LICENSE file
+#   Defines the time in days after which an auto-update gets executed
 #
 class php::phpunit (
   $source      = $php::params::phpunit_source,

--- a/manifests/phpunit/auto_update.pp
+++ b/manifests/phpunit/auto_update.pp
@@ -1,33 +1,15 @@
-# == Class: php::phpunit::auto_update
-#
 # Install phpunit package manager
 #
 # === Parameters
 #
 # [*max_age*]
-# Defines number of days after which phpunit should be updated
+#   Defines number of days after which phpunit should be updated
 #
 # [*source*]
-# Holds URL to the phpunit source file
+#   Holds URL to the phpunit source file
 #
 # [*path*]
-# Holds path to the phpunit executable
-#
-# === Examples
-#
-#  include php::phpunit::auto_update
-#  class { "php::phpunit::auto_update":
-#    "max_age" => 90
-#  }
-#
-# === Authors
-#
-# Christian "Jippi" Winther <jippignu@gmail.com>
-# Robin Gloster <robin.gloster@mayflower.de>
-#
-# === Copyright
-#
-# See LICENSE file
+#   Holds path to the phpunit executable
 #
 class php::phpunit::auto_update (
   $max_age,

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,14 +1,4 @@
-# == Class: php::repo
-#
 # Configure package repository
-#
-# === Authors
-#
-# Robin Gloster <robin.gloster@mayflower.de>
-#
-# === Copyright
-#
-# See LICENSE file
 #
 class php::repo {
 

--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -1,32 +1,21 @@
-# == Class: php::repo::debian
-#
 # Configure debian apt repo
 #
 # === Parameters
 #
 # [*location*]
-#   location of the apt repository
+#   Location of the apt repository
 #
 # [*release*]
-#   release of the apt repository
+#   Release of the apt repository
 #
 # [*repos*]
-#   apt repository names
+#   Apt repository names
 #
 # [*include_src*]
-#   add source source repository
+#   Add source source repository
 #
 # [*dotdeb*]
-#   enable special dotdeb handling
-#
-# === Authors
-#
-# Christian "Jippi" Winther <jippignu@gmail.com>
-# Robin Gloster <robin.gloster@mayflower.de>
-#
-# === Copyright
-#
-# See LICENSE file
+#   Enable special dotdeb handling
 #
 class php::repo::debian(
   $location     = 'http://packages.dotdeb.org',

--- a/manifests/repo/suse.pp
+++ b/manifests/repo/suse.pp
@@ -1,5 +1,3 @@
-# == Class: php::repo::suse
-#
 # Configure suse repo
 #
 # === Parameters
@@ -9,14 +7,6 @@
 #
 # [*baseurl*]
 #   Base URL of the Zypper repository
-#
-# === Authors
-#
-# Robin Gloster <robin.gloster@mayflower.de>
-#
-# === Copyright
-#
-# See LICENSE file
 #
 class php::repo::suse (
   $reponame = 'mayflower-php55',

--- a/manifests/repo/ubuntu.pp
+++ b/manifests/repo/ubuntu.pp
@@ -1,14 +1,4 @@
-# == Class: php::repo::ubuntu
-#
 # Configure ubuntu ppa
-#
-# === Authors
-#
-# Robin Gloster <robin.gloster@mayflower.de>
-#
-# === Copyright
-#
-# See LICENSE file
 #
 class php::repo::ubuntu {
   include '::apt'


### PR DESCRIPTION
This adds documentation generation with puppetlabs-strings on travis-ci. The documentation is pushed to the local `gh-pages` branch and is served on https://mayflower.github.io/puppet-php/ and http://php.puppet.mayflower.de/.

The existing documentation was cleaned up. The authors and license sections and top-level headlines were removed because they're not needed with the default yard templates that puppetlabs-strings uses.