### PR TITLE
$ensure handling for module and extensions

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -107,7 +107,6 @@ class php (
 
   $real_extensions = hiera_hash('php::extensions', $extensions)
   create_resources('::php::extension', $real_extensions, {
-    ensure  => $ensure,
     require => Class['::php::cli'],
     before  => Anchor['php::end']
   })

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,7 +7,7 @@ class php::params {
   $composer_source     = 'https://getcomposer.org/composer.phar'
   $composer_path       = '/usr/local/bin/composer'
   $composer_max_age    = 30
-  $pear_ensure         = 'latest'
+  $pear_ensure         = 'present'
   $pear_package_suffix = 'pear'
   $phpunit_source    = 'https://phar.phpunit.de/phpunit.phar'
   $phpunit_path      = '/usr/local/bin/phpunit'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,7 +2,7 @@
 #
 class php::params {
 
-  $ensure              = 'latest'
+  $ensure              = 'present'
   $fpm_service_enable  = true
   $composer_source     = 'https://getcomposer.org/composer.phar'
   $composer_path       = '/usr/local/bin/composer'

--- a/spec/classes/php_spec.rb
+++ b/spec/classes/php_spec.rb
@@ -9,17 +9,17 @@ describe 'php', :type => :class do
   describe 'when called with no parameters on Debian' do
     it {
       should contain_package('php5-cli').with({
-        'ensure' => 'latest',
+        'ensure' => 'present',
       })
       should contain_class('php::fpm')
       should contain_package('php5-fpm').with({
-        'ensure' => 'latest',
+        'ensure' => 'present',
       })
       should contain_package('php5-dev').with({
-        'ensure' => 'latest',
+        'ensure' => 'present',
       })
       should contain_package('php-pear').with({
-        'ensure' => 'latest',
+        'ensure' => 'present',
       })
       should contain_class('php::composer')
     }
@@ -31,13 +31,13 @@ describe 'php', :type => :class do
                     :path     => '/usr/local/bin:/usr/bin:/bin' } }
     it {
       should contain_package('php5').with({
-        'ensure' => 'latest',
+        'ensure' => 'present',
       })
       should contain_package('php5-devel').with({
-        'ensure' => 'latest',
+        'ensure' => 'present',
       })
       should contain_package('php5-pear').with({
-        'ensure' => 'latest',
+        'ensure' => 'present',
       })
       should_not contain_package('php5-cli')
       should_not contain_package('php5-dev')


### PR DESCRIPTION
I was trying to pin to a specific PHP version and encountered some problems with the module.

This is the node data I was using (i.e. `common.yaml` in wasted):
```yaml
php::ensure: 5.5.9+dfsg-1ubuntu4.9
php::fpm::ensure: 5.5.9+dfsg-1ubuntu4.9
php::cli::ensure: 5.5.9+dfsg-1ubuntu4.9
php::manage_repo: false

component::php::manage_repo: true
component::php::repo::repo:
  jenkins_php5.5.5.9:
    key: F5067765
    key_source: https://jenkins.example.com/php/PUBKEY.gpg
    location: http://jenkins.example.com/php/
    repos: main
    include_src: false
```
This is supposed to pin to 5.5.9, but some modules have different versions than the PHP core (see commit message) resulting in a broken install (package/version not available).

I've worked around this by creating all extensions outside of the module and then passing all the exts into the component, like this:
```puppet
class component::php (
  $extensions = {}
) {
  contain ::php

  create_resources('::php::extension', $extensions, { ensure => present })
 }
```