### PR TITLE
Bugfix: changed - to _ to match default value yum::repo::remi_php56

### DIFF
--- a/manifests/repo/redhat.pp
+++ b/manifests/repo/redhat.pp
@@ -7,7 +7,7 @@
 #
 
 class php::repo::redhat (
-  $yum_repo = 'remi-php56',
+  $yum_repo = 'remi_php56',
 ) {
   contain "::yum::repo::${yum_repo}"
 }


### PR DESCRIPTION
See:
https://github.com/example42/puppet-yum/blob/master/manifests/repo/remi_php56.pp#L5