### PR TITLE
Ensure extension setting prefix

### DIFF
--- a/lib/puppet/parser/functions/ensure_prefix.rb
+++ b/lib/puppet/parser/functions/ensure_prefix.rb
@@ -1,0 +1,56 @@
+
+module Puppet::Parser::Functions
+  newfunction(:ensure_prefix, :type => :rvalue, :doc => <<-EOS
+This function ensures a prefix for all elements in an array or the keys in a hash.
+
+*Examples:*
+
+  ensure_prefix({'a' => 1, 'b' => 2, 'p.c' => 3}, 'p.')
+
+Will return:
+  {
+    'p.a' => 1,
+    'p.b' => 2,
+    'p.c' => 3,
+  }
+
+  ensure_prefix(['a', 'p.b', 'c'], 'p.')
+
+Will return:
+  ['p.a', 'p.b', 'p.c']
+EOS
+  ) do |arguments|
+
+    raise(Puppet::ParseError, "ensure_prefix(): Wrong number of arguments " +
+      "given (#{arguments.size} for 2)") if arguments.size < 2
+
+    enumerable = arguments[0]
+
+    unless enumerable.is_a?(Array) or enumerable.is_a?(Hash)
+      raise Puppet::ParseError, "ensure_prefix(): expected first argument to be an Array or a Hash, got #{enumerable.inspect}"
+    end
+
+    prefix = arguments[1] if arguments[1]
+
+    if prefix
+      unless prefix.is_a?(String)
+        raise Puppet::ParseError, "ensure_prefix(): expected second argument to be a String, got #{prefix.inspect}"
+      end
+    end
+
+    if enumerable.is_a?(Array)
+      # Turn everything into string same as join would do ...
+      result = enumerable.collect do |i|
+        i = i.to_s
+        prefix && !i.start_with?(prefix) ? prefix + i : i
+      end
+    else
+      result = Hash[enumerable.map do |k,v|
+        k = k.to_s
+        [ prefix && !k.start_with?(prefix) ? prefix + k : k, v ]
+      end]
+    end
+
+    return result
+  end
+end

--- a/manifests/extension.pp
+++ b/manifests/extension.pp
@@ -117,7 +117,7 @@ define php::extension(
 
   # Ensure "<extension>." prefix is present in setting keys if requested
   if $settings_prefix {
-    $full_settings = ensure_prefix($settings, "${name}.")
+    $full_settings = ensure_prefix($settings, "${lowercase_title}.")
   } else {
     $full_settings = $settings
   }

--- a/manifests/extension.pp
+++ b/manifests/extension.pp
@@ -34,8 +34,8 @@
 #   Nested hash of global config parameters for php.ini
 #
 # [*settings_prefix*]
-#  Boolean parameter, whether to prefix all setting keys with
-#  the extension name. Defaults to false.
+#   Boolean/String parameter, whether to prefix all setting keys with
+#   the extension name or specified name. Defaults to false.
 #
 define php::extension(
   $ensure            = 'installed',
@@ -117,7 +117,12 @@ define php::extension(
 
   # Ensure "<extension>." prefix is present in setting keys if requested
   if $settings_prefix {
-    $full_settings = ensure_prefix($settings, "${lowercase_title}.")
+    if is_string($settings_prefix) {
+      $full_settings_prefix = $settings_prefix
+    } else {
+      $full_settings_prefix = $lowercase_title
+    }
+    $full_settings = ensure_prefix($settings, "${full_settings_prefix}.")
   } else {
     $full_settings = $settings
   }

--- a/manifests/extension.pp
+++ b/manifests/extension.pp
@@ -35,7 +35,7 @@
 #
 # [*settings_prefix*]
 #  Boolean parameter, whether to prefix all setting keys with
-#  the extension name. Defaults to true.
+#  the extension name. Defaults to false.
 #
 define php::extension(
   $ensure            = 'installed',
@@ -47,7 +47,7 @@ define php::extension(
   $compiler_packages = $::php::params::compiler_packages,
   $zend              = false,
   $settings          = {},
-  $settings_prefix   = true,
+  $settings_prefix   = false,
 ) {
 
   if $caller_module_name != $module_name {

--- a/spec/defines/extension_spec.rb
+++ b/spec/defines/extension_spec.rb
@@ -19,17 +19,17 @@ describe 'php::extension' do
       should contain_php__config('json').with({
         :file   => '/etc/php5/mods-available/json.ini',
         :config => {
-          'json.test' => 'foo'
+          'test' => 'foo'
         },
       })
     }
   end
 
-  context 'skip settings prefix if requested' do
+  context 'add settings prefix if requested' do
     let(:title) {'json' }
     let(:params) {{
       :name            => 'json',
-      :settings_prefix => false,
+      :settings_prefix => true,
       :settings        => {
         'test' => 'foo'
       }
@@ -38,7 +38,7 @@ describe 'php::extension' do
     it {
       should contain_php__config('json').with({
         :config => {
-          'test' => 'foo'
+          'json.test' => 'foo'
         }
       })
     }
@@ -72,7 +72,7 @@ describe 'php::extension' do
         :file   => '/etc/php5/mods-available/json.ini',
         :config => {
           'extension' => 'nice_name.so',
-          'nice_name.test'      => 'foo'
+          'test'      => 'foo'
         },
       })
     }

--- a/spec/defines/extension_spec.rb
+++ b/spec/defines/extension_spec.rb
@@ -44,6 +44,25 @@ describe 'php::extension' do
     }
   end
 
+  context 'use specific settings prefix if requested' do
+    let(:title) {'json' }
+    let(:params) {{
+      :name            => 'json',
+      :settings_prefix => 'bar',
+      :settings        => {
+        'test' => 'foo'
+      }
+    }}
+
+    it {
+      should contain_php__config('json').with({
+        :config => {
+          'bar.test' => 'foo'
+        }
+      })
+    }
+  end
+
   context 'non-pecl extensions cannot be configured as zend' do
     let(:title) { 'xdebug' }
     let(:params) {{

--- a/spec/defines/extension_spec.rb
+++ b/spec/defines/extension_spec.rb
@@ -19,7 +19,7 @@ describe 'php::extension' do
       should contain_php__config('json').with({
         :file   => '/etc/php5/mods-available/json.ini',
         :config => {
-          'test' => 'foo'
+          'json.test' => 'foo'
         },
       })
     }
@@ -53,7 +53,7 @@ describe 'php::extension' do
         :file   => '/etc/php5/mods-available/json.ini',
         :config => {
           'extension' => 'nice_name.so',
-          'test'      => 'foo'
+          'nice_name.test'      => 'foo'
         },
       })
     }

--- a/spec/defines/extension_spec.rb
+++ b/spec/defines/extension_spec.rb
@@ -25,6 +25,25 @@ describe 'php::extension' do
     }
   end
 
+  context 'skip settings prefix if requested' do
+    let(:title) {'json' }
+    let(:params) {{
+      :name            => 'json',
+      :settings_prefix => false,
+      :settings        => {
+        'test' => 'foo'
+      }
+    }}
+
+    it {
+      should contain_php__config('json').with({
+        :config => {
+          'test' => 'foo'
+        }
+      })
+    }
+  end
+
   context 'non-pecl extensions cannot be configured as zend' do
     let(:title) { 'xdebug' }
     let(:params) {{


### PR DESCRIPTION
By default extension setting keys are now prefixed with `<name>.`
If the prefix is already present, nothing is changed.

This allows for simpler extension configuration by simply passing
the setting name without prefix.

Fixes #81