### PR TITLE
Remove pool's default listen_allowed_clients and add conditional in template

### DIFF
--- a/manifests/fpm/pool.pp
+++ b/manifests/fpm/pool.pp
@@ -93,7 +93,7 @@ define php::fpm::pool (
   $listen = '127.0.0.1:9000',
   # Puppet does not allow dots in variable names
   $listen_backlog = '-1',
-  $listen_allowed_clients = '127.0.0.1',
+  $listen_allowed_clients = undef,
   $listen_owner = undef,
   $listen_group = undef,
   $listen_mode = undef,

--- a/templates/fpm/pool.conf.erb
+++ b/templates/fpm/pool.conf.erb
@@ -12,7 +12,11 @@ listen.backlog = <%= @listen_backlog %>
 ; must be separated by a comma. If this value is left blank, connections will be
 ; accepted from any ip address.
 ; Default Value: any
+<% if @listen_allowed_clients -%>
 listen.allowed_clients = <%= @listen_allowed_clients %>
+<% else -%>
+;listen.allowed_clients = 127.0.0.1
+<% end -%>
 
 ; Set permissions for unix socket, if one is used. In Linux, read/write
 ; permissions must be set in order to allow connections from a web server. Many


### PR DESCRIPTION
The only way to open the service to any IP is to not include the `listen.allowed_clients` option in the pool. (Since I want to manage this through AWS security groups, it is still safe)
Can't set an empty value in YAML, apparently.

**WARNING**: This means a change in behaviour!!!
Those that set `listen` to something other than 127.0.0.1 and trust the default to allow only requests sourced from 127.0.0.1, will find this change allows requests from any source.