### PR TITLE
emergency_restart_threshold is number

### DIFF
--- a/manifests/fpm/config.pp
+++ b/manifests/fpm/config.pp
@@ -73,7 +73,7 @@ class php::fpm::config(
 
   validate_absolute_path($pool_base_dir)
   validate_string($log_level)
-  validate_re($emergency_restart_threshold, $interval_re)
+  validate_re($emergency_restart_threshold, $number_re)
   validate_re($emergency_restart_interval, $interval_re)
   validate_re($process_control_timeout, $interval_re)
   validate_string($log_owner)


### PR DESCRIPTION
Although it works anyway because `[smhd]` is optional in `interval_re`, `emergency_restart_threshold` is an integer and should be checked against `number_re` instead.

From [PHP documentation](http://php.net/manual/en/install.fpm.configuration.php):
```
emergency_restart_threshold int
If this number of child processes exit with SIGSEGV or SIGBUS within the time interval set by emergency_restart_interval then FPM will restart. A value of 0 means 'Off'. Default value: 0 (Off).
```
