### PR TITLE
Allow sending errors to syslog

### DIFF
--- a/manifests/fpm/config.pp
+++ b/manifests/fpm/config.pp
@@ -24,6 +24,10 @@
 #   Whether to purge pool config files not created
 #   by this module
 #
+# [*error_log*]
+# Path to error log file. If it's set to "syslog", log is
+# sent to syslogd instead of being written in a local file.
+#
 # [*log_level*]
 #   The php-fpm log level
 #
@@ -53,6 +57,7 @@ class php::fpm::config(
   $settings                    = {},
   $pool_base_dir               = $::php::params::fpm_pool_dir,
   $pool_purge                  = false,
+  $error_log                   = $::php::params::fpm_error_log,
   $log_level                   = 'notice',
   $emergency_restart_threshold = '0',
   $emergency_restart_interval  = '0',
@@ -72,6 +77,7 @@ class php::fpm::config(
   $interval_re = '^\d+[smhd]?$'
 
   validate_absolute_path($pool_base_dir)
+  validate_string($error_log)
   validate_string($log_level)
   validate_re($emergency_restart_threshold, $number_re)
   validate_re($emergency_restart_interval, $interval_re)

--- a/manifests/fpm/config.pp
+++ b/manifests/fpm/config.pp
@@ -49,6 +49,12 @@
 # [*log_dir_mode*]
 #   The octal mode of the directory
 #
+# [*syslog_facility*]
+# Used to specify what type of program is logging the message
+#
+# [*syslog_ident*]
+# Prepended to every message
+#
 class php::fpm::config(
   $config_file                 = $::php::params::fpm_config_file,
   $user                        = $::php::params::fpm_user,
@@ -66,6 +72,8 @@ class php::fpm::config(
   $log_group                   = $::php::params::fpm_group,
   $log_dir_mode                = '0770',
   $root_group                  = $::php::params::root_group,
+  $syslog_facility             = 'daemon',
+  $syslog_ident                = 'php-fpm',
 ) inherits ::php::params {
 
   validate_string($user)
@@ -85,6 +93,8 @@ class php::fpm::config(
   validate_string($log_owner)
   validate_string($log_group)
   validate_re($log_dir_mode, $number_re)
+  validate_string($syslog_facility)
+  validate_string($syslog_ident)
 
 
   if $caller_module_name != $module_name {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,6 +22,7 @@ class php::params {
       $cli_inifile             = "${config_root}/cli/php.ini"
       $dev_package_suffix      = 'dev'
       $fpm_config_file         = "${config_root}/fpm/php-fpm.conf"
+      $fpm_error_log           = '/var/log/php5-fpm.log'
       $fpm_inifile             = "${config_root}/fpm/php.ini"
       $fpm_package_suffix      = 'fpm'
       $fpm_pool_dir            = "${config_root}/fpm/pool.d"
@@ -41,6 +42,7 @@ class php::params {
       $cli_inifile             = "${config_root}/cli/php.ini"
       $dev_package_suffix      = 'devel'
       $fpm_config_file         = "${config_root}/fpm/php-fpm.conf"
+      $fpm_error_log           = '/var/log/php5-fpm.log'
       $fpm_inifile             = "${config_root}/fpm/php.ini"
       $fpm_package_suffix      = 'fpm'
       $fpm_pool_dir            = "${config_root}/fpm/pool.d"
@@ -69,6 +71,7 @@ class php::params {
       $cli_inifile             = '/etc/php-cli.ini'
       $dev_package_suffix      = 'devel'
       $fpm_config_file         = '/etc/php-fpm.conf'
+      $fpm_error_log           = '/var/log/php-fpm/error.log'
       $fpm_inifile             = '/etc/php.ini'
       $fpm_package_suffix      = 'fpm'
       $fpm_pool_dir            = '/etc/php-fpm.d'
@@ -91,6 +94,7 @@ class php::params {
       $cli_inifile             = "${config_root}/php-cli.ini"
       $dev_package_suffix      = undef
       $fpm_config_file         = "${config_root}/php-fpm.conf"
+      $fpm_error_log           = '/var/log/php-fpm.log'
       $fpm_inifile             = "${config_root}/php.ini"
       $fpm_package_suffix      = undef
       $fpm_pool_dir            = "${config_root}/php-fpm.d"

--- a/templates/fpm/php-fpm.conf.erb
+++ b/templates/fpm/php-fpm.conf.erb
@@ -35,13 +35,7 @@ pid = /var/run/php5-fpm.pid
 ; in a local file.
 ; Note: the default prefix is /var
 ; Default Value: log/php-fpm.log
-<% if @osfamily == "FreeBSD" %>
-error_log = /var/log/php-fpm.log
-<% elsif @osfamily == "RedHat" %>
-error_log = /var/log/php-fpm/error.log
-<% else %>
-error_log = /var/log/php5-fpm.log
-<% end %>
+error_log = <%= @error_log %>
 
 ; syslog_facility is used to specify what type of program is logging the
 ; message. This lets syslogd specify that messages from different facilities

--- a/templates/fpm/php-fpm.conf.erb
+++ b/templates/fpm/php-fpm.conf.erb
@@ -42,13 +42,13 @@ error_log = <%= @error_log %>
 ; will be handled differently.
 ; See syslog(3) for possible values (ex daemon equiv LOG_DAEMON)
 ; Default Value: daemon
-;syslog.facility = daemon
+syslog.facility = <%= @syslog_facility %>
 
 ; syslog_ident is prepended to every message. If you have multiple FPM
 ; instances running on the same server, you can change the default value
 ; which must suit common needs.
 ; Default Value: php-fpm
-;syslog.ident = php-fpm
+syslog.ident = <%= @syslog_ident %>
 
 ; Log level
 ; Possible Values: alert, error, warning, notice, debug


### PR DESCRIPTION
Allows for any value to be set for error_log, and adds configuration for syslog.ident and syslog.facility.

Fixes #95 