### PR TITLE
Add option to include config files on pool

### DIFF
--- a/manifests/fpm/pool.pp
+++ b/manifests/fpm/pool.pp
@@ -66,6 +66,9 @@
 #
 # [*catch_workers_output*]
 #
+# [*include*]
+#   Other configuration files to include on this pool
+#
 # [*env*]
 #   List of environment variables that are passed to the php-fpm from the
 #   outside and will be available to php scripts in this pool
@@ -117,6 +120,7 @@ define php::fpm::pool (
   $chroot = undef,
   $chdir = undef,
   $catch_workers_output = 'no',
+  $include = undef,
   $env = [],
   $env_value = {},
   $php_value = {},

--- a/templates/fpm/pool.conf.erb
+++ b/templates/fpm/pool.conf.erb
@@ -212,6 +212,18 @@ chdir = <%= @chdir %>
 ; Default Value: no
 catch_workers_output = <%= @catch_workers_output %>
 
+; Include one or more files. If glob(3) exists, it is used to include a bunch of
+; files from a glob(3) pattern. This directive can be used everywhere in the
+; file.
+; Relative path can also be used. They will be prefixed by:
+;  - the global prefix if it's been set (-p arguement)
+;  - /usr otherwise
+<% if @include -%>
+include=<%= @include %>
+<% else -%>
+;include=/etc/php5/fpm/*.conf
+<% end -%>
+
 ; Pass environment variables like LD_LIBRARY_PATH. All $VARIABLEs are taken from
 ; the current environment.
 ; Default Value: clean env


### PR DESCRIPTION
Fpm pool accepts include option which include other files on tha pool.

This is useful to include enviroment variables on a different files by
example.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mayflower/puppet-php/103)
<!-- Reviewable:end -->
