### PR TITLE
include /bin in suse path

### DIFF
--- a/manifests/repo/suse.pp
+++ b/manifests/repo/suse.pp
@@ -19,7 +19,7 @@ class php::repo::suse (
   } ~>
   exec { 'zypprepo-accept-key':
     command     => 'zypper --gpg-auto-import-keys update -y',
-    path        => '/usr/bin',
+    path        => '/usr/bin:/bin',
     refreshonly => true,
   }
 }


### PR DESCRIPTION
This is more related to a package doing things wrong, but anyway, I'm getting:
```
[...]
Notice: /Stage[main]/Php::Repo/Php::Repo::Suse/Exec[zypprepo-accept-key]/returns: (with --nodeps --force) Error: Subprocess failed. Error: RPM failed: Can't exec 'rpm' (No such file or directory).
[...]
Error: /Stage[main]/Php::Repo/Php::Repo::Suse/Exec[zypprepo-accept-key]: zypper --gpg-auto-import-keys update -y returned 4 instead of one of [0]
[...]
```