### PR TITLE
Add check if value is empty in the pool.conf.erb template

### DIFF
--- a/templates/fpm/pool.conf.erb
+++ b/templates/fpm/pool.conf.erb
@@ -236,7 +236,9 @@ include=<%= @include %>
 env[<%= var %>] = $<%= var %>
 <% end -%>
 <% @env_value.sort_by {|key,value| key}.each do |key,value| -%>
+<% if !value.empty? -%>
 env[<%= key %>] = '<%= value %>'
+<% end -%>
 <% end -%>
 
 ; Additional php.ini defines, specific to this pool of workers. These settings


### PR DESCRIPTION
The php fpm failed to start if the configuration for a pool contains something like 
`env[FOOBAR] = `

So with this fix the defect configuration will be prevent.