### PR TITLE
Fix reloading php-fpm on trusty & utopic

### DIFF
--- a/manifests/fpm/service.pp
+++ b/manifests/fpm/service.pp
@@ -21,11 +21,36 @@ class php::fpm::service(
     warning('php::fpm::service is private')
   }
 
+  $reload = "service ${service_name} reload"
+
+  if $::osfamily == 'Debian' {
+    # Precise upstart doesn't support reload signals, so use
+    # regular service restart instead
+    if $::lsbdistcodename == 'precise' {
+      $restart = undef
+    } else {
+      $restart = $reload
+    }
+
+    # Create an override to use a reload signal as trusty and utopic's
+    # upstart version supports this
+    if ($::lsbdistcodename == 'trusty' or
+        $::lsbdistcodename == 'utopic') {
+      file { "/etc/init/${service_name}.override":
+        content => 'reload signal USR2',
+        before  => Service[$service_name],
+      }
+    }
+  } else {
+    $restart = $reload
+  }
+
   service { $service_name:
-    ensure    => $ensure,
-    enable    => $enable,
-    restart   => "service ${service_name} reload",
-    hasstatus => true,
+    ensure     => $ensure,
+    enable     => $enable,
+    hasrestart => true,
+    restart    => $restart,
+    hasstatus  => true,
   }
 
   ::Php::Extension <| |> ~> Service[$service_name]


### PR DESCRIPTION
Ubuntu versions newer than precise support reload signals but that feature is disabled by the package maintainer because he builds packages with the same upstart config for precise, too.

But because we actually use reload, refreshing the service doesn't work correctly which leads to php-fpm child processes that never get killed. These processes prevent restarting php-fpm altogether. The only fix is manually killing them.

See https://bugs.launchpad.net/ubuntu/+source/php5/+bug/1242376 for reference.

This patch ensures that reloading is not used on precise and the reload signal USR2 is used for all other supported versions of Ubuntu by creating an upstart override file.

/cc @globin @exi