### PR TITLE
Embedded SAPI support (php.ini)

### DIFF
--- a/manifests/embedded.pp
+++ b/manifests/embedded.pp
@@ -1,0 +1,45 @@
+# Install and configure php embedded SAPI
+#
+# === Parameters
+#
+# [*inifile*]
+#   The path to the ini php5-embeded ini file
+#
+# [*settings*]
+#   Hash with nested hash of key => value to set in inifile
+#
+class php::embedded(
+  $ensure   = $::php::ensure,
+  $package  =
+    "${::php::package_prefix}${::php::params::embedded_package_suffix}",
+  $inifile  = $::php::params::embedded_inifile,
+  $settings = {},
+) inherits ::php::params {
+
+  if $caller_module_name != $module_name {
+    warning('php::embedded is private')
+  }
+
+  validate_absolute_path($inifile)
+  validate_hash($settings)
+
+  $real_settings = deep_merge(
+    $settings,
+    hiera_hash('php::embedded::settings', {})
+  )
+
+  $real_package = $::osfamily ? {
+    'Debian' => "lib${package}",
+    default   => $package,
+  }
+
+  package { $real_package:
+    ensure  => $ensure,
+    require => Class['::php::packages'],
+  }->
+  ::php::config { 'embedded':
+    file   => $inifile,
+    config => $real_settings,
+  }
+  
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,6 +37,7 @@ class php (
   $ensure         = $::php::params::ensure,
   $manage_repos   = $::php::params::manage_repos,
   $fpm            = true,
+  $embedded       = false,
   $dev            = true,
   $composer       = true,
   $pear           = true,
@@ -50,6 +51,7 @@ class php (
   validate_string($ensure)
   validate_bool($manage_repos)
   validate_bool($fpm)
+  validate_bool($embedded)
   validate_bool($dev)
   validate_bool($composer)
   validate_bool($pear)
@@ -76,6 +78,18 @@ class php (
   if $fpm {
     Anchor['php::begin'] ->
       class { '::php::fpm':
+        settings => $real_settings,
+      } ->
+    Anchor['php::end']
+  }
+  if $embedded {
+    if $::osfamily == 'RedHat' and $fpm {
+      # Both fpm and embeded SAPIs are using same php.ini
+      fail('Enabling both cli and embedded sapis is not currently supported')
+    }
+    
+    Anchor['php::begin'] ->
+      class { '::php::embedded':
         settings => $real_settings,
       } ->
     Anchor['php::end']

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -29,6 +29,8 @@ class php::params {
       $fpm_service_name        = 'php5-fpm'
       $fpm_user                = 'www-data'
       $fpm_group               = 'www-data'
+      $embedded_package_suffix = 'embed'
+      $embedded_inifile        = "${config_root}/embed/php.ini"
       $package_prefix          = 'php5-'
       $compiler_packages       = 'build-essential'
       $manage_repos            = $::lsbdistcodename == 'wheezy'
@@ -49,6 +51,8 @@ class php::params {
       $fpm_service_name        = 'php-fpm'
       $fpm_user                = 'wwwrun'
       $fpm_group               = 'www'
+      $embedded_package_suffix = 'embed'
+      $embedded_inifile        = "${config_root}/embed/php.ini"
       $package_prefix          = 'php5-'
       $manage_repos            = true
       $root_group              = 'root'
@@ -78,6 +82,8 @@ class php::params {
       $fpm_service_name        = 'php-fpm'
       $fpm_user                = 'apache'
       $fpm_group               = 'apache'
+      $embedded_package_suffix = 'embedded'
+      $embedded_inifile        = '/etc/php.ini'
       $package_prefix          = 'php-'
       $compiler_packages       = ['gcc', 'gcc-c++', 'make']
       $manage_repos            = false
@@ -101,6 +107,8 @@ class php::params {
       $fpm_service_name        = 'php-fpm'
       $fpm_user                = 'www'
       $fpm_group               = 'www'
+      $embedded_package_suffix = 'embed'
+      $embedded_inifile        = "${config_root}/php-embed.ini"
       $package_prefix          = 'php56-'
       $compiler_packages       = ['gcc']
       $manage_repos            = false


### PR DESCRIPTION
Support for embedded sapi - configuring specific for sapi `php.ini` as it is only thing I think is needed in this case.
Checked on RedHat and Debian. Fingers crossed for Suse & FreeBSD.