### PR TITLE
PHP custom facts

### DIFF
--- a/lib/facter/phpversion.rb
+++ b/lib/facter/phpversion.rb
@@ -1,0 +1,7 @@
+Facter.add(:phpversion) do
+  setcode do
+    Facter::Util::Resolution.exec('php -v').
+      split("\n").first.split(' ').
+      select { |x| x =~ /^(?:(\d+)\.)(?:(\d+)\.)?(\*|\d+)/ }.first
+  end
+end


### PR DESCRIPTION
I guess only the `phpversion` fact is actually useful, but it's hacky.