### PR TITLE
Include fpm pid file configuration

### DIFF
--- a/manifests/fpm/config.pp
+++ b/manifests/fpm/config.pp
@@ -63,6 +63,7 @@ class php::fpm::config(
   $user                        = $::php::params::fpm_user,
   $group                       = $::php::params::fpm_group,
   $inifile                     = $::php::params::fpm_inifile,
+  $pid_file                    = $::php::params::fpm_pid_file,
   $settings                    = {},
   $pool_base_dir               = $::php::params::fpm_pool_dir,
   $pool_purge                  = false,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,6 +21,7 @@ class php::params {
       $common_package_suffixes = ['cli', 'common']
       $cli_inifile             = "${config_root}/cli/php.ini"
       $dev_package_suffix      = 'dev'
+      $fpm_pid_file            = '/var/run/php5-fpm.pid'
       $fpm_config_file         = "${config_root}/fpm/php-fpm.conf"
       $fpm_error_log           = '/var/log/php5-fpm.log'
       $fpm_inifile             = "${config_root}/fpm/php.ini"
@@ -55,6 +56,7 @@ class php::params {
       $common_package_suffixes = []
       $cli_inifile             = "${config_root}/cli/php.ini"
       $dev_package_suffix      = 'devel'
+      $fpm_pid_file            = '/var/run/php5-fpm.pid'
       $fpm_config_file         = "${config_root}/fpm/php-fpm.conf"
       $fpm_error_log           = '/var/log/php5-fpm.log'
       $fpm_inifile             = "${config_root}/fpm/php.ini"
@@ -84,6 +86,7 @@ class php::params {
       $common_package_suffixes = ['cli', 'common']
       $cli_inifile             = '/etc/php-cli.ini'
       $dev_package_suffix      = 'devel'
+      $fpm_pid_file            = '/var/run/php-fpm/php-fpm.pid'
       $fpm_config_file         = '/etc/php-fpm.conf'
       $fpm_error_log           = '/var/log/php-fpm/error.log'
       $fpm_inifile             = '/etc/php.ini'
@@ -107,6 +110,7 @@ class php::params {
       $common_package_suffixes = ['extensions']
       $cli_inifile             = "${config_root}/php-cli.ini"
       $dev_package_suffix      = undef
+      $fpm_pid_file            = '/var/run/php-fpm.pid'
       $fpm_config_file         = "${config_root}/php-fpm.conf"
       $fpm_error_log           = '/var/log/php-fpm.log'
       $fpm_inifile             = "${config_root}/php.ini"

--- a/templates/fpm/php-fpm.conf.erb
+++ b/templates/fpm/php-fpm.conf.erb
@@ -22,13 +22,7 @@
 ; Pid file
 ; Note: the default prefix is /var
 ; Default Value: none
-<% if @osfamily == "FreeBSD" %>
-pid = /var/run/php-fpm.pid
-<% elsif @osfamily == "RedHat" %>
-pid = /var/run/php-fpm/php-fpm.pid
-<% else %>
-pid = /var/run/php5-fpm.pid
-<% end %>
+pid = <%= @pid_file %>
 
 ; Error log file
 ; If it's set to "syslog", log is sent to syslogd instead of being written


### PR DESCRIPTION
Include a option to configure the fpm pid file. As in some distros (and
pgp versions) the pid file on the init script changes, we need to
provide a way to the user override the fpm pid file.

For example, at RedHat (AmazonLinux) the php56 package leves at:
`
/var/run/php-fpm/php-fpm-5.6.pid
`

With this change, the Amazon Linux user with the php56 package should
configure on hiera the key:

```yaml
php::fpm::config::pid_file: /var/run/php-fpm/php-fpm-5.6.pid
```