### PR TITLE
Allow removal of config values

### DIFF
--- a/manifests/config/setting.pp
+++ b/manifests/config/setting.pp
@@ -50,6 +50,6 @@ define php::config::setting(
     value   => $value,
     path    => $file,
     section => $section,
-    setting => $setting
+    setting => $setting,
   }
 }

--- a/manifests/config/setting.pp
+++ b/manifests/config/setting.pp
@@ -46,10 +46,10 @@ define php::config::setting(
   }
 
   ini_setting { $name:
+    ensure  => $ensure,
     value   => $value,
     path    => $file,
     section => $section,
-    setting => $setting,
-    ensure  => $ensure
+    setting => $setting
   }
 }

--- a/manifests/config/setting.pp
+++ b/manifests/config/setting.pp
@@ -39,10 +39,10 @@ define php::config::setting(
     $setting = $split_name[1]
   }
 
-  if $value {
-    $ensure = 'present'
-  } else {
+  if $value == undef {
     $ensure = 'absent'
+  } else {
+    $ensure = 'present'
   }
 
   ini_setting { $name:

--- a/manifests/config/setting.pp
+++ b/manifests/config/setting.pp
@@ -39,10 +39,16 @@ define php::config::setting(
     $setting = $split_name[1]
   }
 
+  if $value {
+    $ensure = 'present'
+  } else {
+    $ensure = 'absent'
+  }
+
   ini_setting { $name:
     value   => $value,
     path    => $file,
-    section => $section,
     setting => $setting,
+    ensure  => $ensure
   }
 }

--- a/manifests/config/setting.pp
+++ b/manifests/config/setting.pp
@@ -48,6 +48,7 @@ define php::config::setting(
   ini_setting { $name:
     value   => $value,
     path    => $file,
+    section => $section,
     setting => $setting,
     ensure  => $ensure
   }


### PR DESCRIPTION
With this change, config values can be removed entirely.

For example, this will remove the `date.timezone` configuration entry:

```puppet
class { '::php':
  settings => {
    'Date/date.timezone' => undef
  }
}
```