### PR TITLE
Make sure auto_discover is set *before* installing packages

### DIFF
--- a/lib/puppet/provider/package/pear.rb
+++ b/lib/puppet/provider/package/pear.rb
@@ -85,7 +85,7 @@ Puppet::Type.type(:package).provide :pear, :parent => Puppet::Provider::Package 
   end
 
   def install(useversion = true)
-    command = ["upgrade"]
+    command = ["-D", "auto_discover=1", "upgrade"]
     if @resource[:install_options]
       command << @resource[:install_options]
     else

--- a/manifests/pear.pp
+++ b/manifests/pear.pp
@@ -43,11 +43,4 @@ class php::pear (
     require => Class['::php::cli'],
   }
 
-  exec { '::php::pear::auto_discover':
-    command => 'pear config-set auto_discover 1 system',
-    unless  => 'pear config-get auto_discover system | grep -q 1',
-    path    => ['/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/',
-                '/usr/local/bin', '/usr/local/sbin'],
-    require => Package[$package_name],
-  }
 }


### PR DESCRIPTION
I may be totally wrong here, but shouldn't this be set up before the packages are installed?

For me, package installation fails (on a completely fresh box) with the hint to use "pear channel-discover pear...." to initialize or pear config-set auto_discover 1".
