### PR TITLE
Make the ::php::extension module part of the public API

### DIFF
--- a/manifests/extension.pp
+++ b/manifests/extension.pp
@@ -59,10 +59,6 @@ define php::extension(
   $settings_prefix   = false,
 ) {
 
-  if $caller_module_name != $module_name {
-    warning('php::extension is private')
-  }
-
   validate_string($ensure)
   validate_string($package_prefix)
   validate_string($so_name)


### PR DESCRIPTION
See #126 for the initial request.

I did a quick check and did not find any cross-class assumptions or dependencies, so this should be a safe change.
