### PR TITLE
Enable extension when package already installed

### DIFF
--- a/manifests/extension.pp
+++ b/manifests/extension.pp
@@ -183,10 +183,9 @@ define php::extension(
     $cmd = "/usr/sbin/php5enmod ${lowercase_title}"
 
     exec { $cmd:
-      refreshonly => true,
+      unless  => "/usr/sbin/php5query -s cli -m ${lowercase_title}",
+      require =>::Php::Config[$title],
     }
-
-    ::Php::Config[$title] ~> Exec[$cmd]
 
     if $::php::fpm {
       Package[$::php::fpm::package] ~> Exec[$cmd]


### PR DESCRIPTION
The `php5query` command needs a SAPI. We use `cli` here and hope that all extensions are managed for all SAPIs consistently.