### PR TITLE
Separate php.ini settings from fpm settings

### DIFF
--- a/manifests/global.pp
+++ b/manifests/global.pp
@@ -1,0 +1,33 @@
+# Install and configure mod_php for fpm
+#
+# === Parameters
+#
+# [*inifile*]
+#   Absolute path to the global php.ini file. Defaults
+#   to the OS specific default location as defined in params.
+# [*settings*]
+#   Hash of settings to apply to the global php.ini file.
+#   Defaults to OS specific defaults (i.e. add nothing)
+#
+
+#
+class php::cli(
+  $inifile  = $::php::params::config_root_inifile,
+  $settings = {}
+) inherits ::php::params {
+
+  if $caller_module_name != $module_name {
+    warning('php::global is private')
+  }
+
+  validate_absolute_path($inifile)
+  validate_hash($settings)
+
+  # No deep merging required since the settings we have are the global settings.
+  $real_settings = $settings
+
+  ::php::config { 'global':
+    file   => $inifile,
+    config => $real_settings,
+  }
+}

--- a/manifests/global.pp
+++ b/manifests/global.pp
@@ -11,7 +11,7 @@
 #
 
 #
-class php::cli(
+class php::global(
   $inifile  = $::php::params::config_root_inifile,
   $settings = {}
 ) inherits ::php::params {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -76,6 +76,13 @@ class php (
     } ->
   anchor { 'php::end': }
 
+  # Configure global PHP settings in php.ini
+  Anchor['php::begin'] ->
+  class {'::php::global':
+    settings => $real_settings,
+  } ->
+  anchor { 'php::end': }
+
   if $fpm {
     Anchor['php::begin'] ->
       class { '::php::fpm':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -81,7 +81,7 @@ class php (
   class {'::php::global':
     settings => $real_settings,
   } ->
-  Anchor ['php::end':]
+  Anchor ['php::end']
 
   if $fpm {
     Anchor['php::begin'] ->

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -81,7 +81,7 @@ class php (
   class {'::php::global':
     settings => $real_settings,
   } ->
-  anchor { 'php::end': }
+  Anchor ['php::end':]
 
   if $fpm {
     Anchor['php::begin'] ->

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,6 +17,7 @@ class php::params {
     'Debian': {
       $config_root             = '/etc/php5'
       $config_root_ini         = "${::php::params::config_root}/mods-available"
+      $config_root_inifile     = "${config_root}/php.ini"
       $common_package_names    = []
       $common_package_suffixes = ['cli', 'common']
       $cli_inifile             = "${config_root}/cli/php.ini"
@@ -52,6 +53,7 @@ class php::params {
     'Suse': {
       $config_root             = '/etc/php5'
       $config_root_ini         = "${config_root}/conf.d"
+      $config_root_inifile     = "${config_root}/php.ini"
       $common_package_names    = ['php5']
       $common_package_suffixes = []
       $cli_inifile             = "${config_root}/cli/php.ini"
@@ -82,6 +84,7 @@ class php::params {
     }
     'RedHat': {
       $config_root_ini         = '/etc/php.d'
+      $config_root_inifile     = '/etc/php.ini'
       $common_package_names    = []
       $common_package_suffixes = ['cli', 'common']
       $cli_inifile             = '/etc/php-cli.ini'
@@ -89,7 +92,7 @@ class php::params {
       $fpm_pid_file            = '/var/run/php-fpm/php-fpm.pid'
       $fpm_config_file         = '/etc/php-fpm.conf'
       $fpm_error_log           = '/var/log/php-fpm/error.log'
-      $fpm_inifile             = '/etc/php.ini'
+      $fpm_inifile             = '/etc/php-fpm.ini'
       $fpm_package_suffix      = 'fpm'
       $fpm_pool_dir            = '/etc/php-fpm.d'
       $fpm_service_name        = 'php-fpm'
@@ -103,6 +106,7 @@ class php::params {
     'FreeBSD': {
       $config_root             = '/usr/local/etc'
       $config_root_ini         = "${config_root}/php"
+      $config_root_inifile     = "${config_root}/php.ini"
       # No common packages, because the required PHP base package will be
       # pulled in as a dependency. This preserves the ability to choose
       # any available PHP version by setting the 'package_prefix' parameter.
@@ -113,7 +117,7 @@ class php::params {
       $fpm_pid_file            = '/var/run/php-fpm.pid'
       $fpm_config_file         = "${config_root}/php-fpm.conf"
       $fpm_error_log           = '/var/log/php-fpm.log'
-      $fpm_inifile             = "${config_root}/php.ini"
+      $fpm_inifile             = "${config_root}/php-fpm.ini"
       $fpm_package_suffix      = undef
       $fpm_pool_dir            = "${config_root}/php-fpm.d"
       $fpm_service_name        = 'php-fpm'


### PR DESCRIPTION
Alright, so this is going to need some testing. I added a new variable to store the location of php.ini for each OS. Everything except Redhat was an "educated guess" as to the proper location.

The new "php::global" class runs in the init.pp file and sets values in the file (similarly to php-cli.ini)

The fpm settings have been moved into a php-fpm.ini file which according to the PHP docs should be autoloaded based on the package name (exactly the same way php-cli.ini works).

I provisioned a machine and tested the config. Appears to work and nothing breaks. But like I said, I haven't been able to test the other OSes yet.