### PR TITLE
removing any reference of hiera and replacing it with Puppet DSL code

### DIFF
--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -8,7 +8,7 @@
 # [*settings*]
 #   Hash with nested hash of key => value to set in inifile
 #
-class php::cli(
+class php::cli (
   $inifile  = $::php::params::cli_inifile,
   $settings = {}
 ) inherits ::php::params {
@@ -20,10 +20,8 @@ class php::cli(
   validate_absolute_path($inifile)
   validate_hash($settings)
 
-  $real_settings = deep_merge($settings, hiera_hash('php::cli::settings', {}))
-
   ::php::config { 'cli':
     file   => $inifile,
-    config => $real_settings,
+    config => $settings,
   }
 }

--- a/manifests/embedded.pp
+++ b/manifests/embedded.pp
@@ -23,10 +23,6 @@ class php::embedded(
   validate_absolute_path($inifile)
   validate_hash($settings)
 
-  $real_settings = deep_merge(
-    $settings,
-    hiera_hash('php::embedded::settings', {})
-  )
 
   $real_package = $::osfamily ? {
     'Debian' => "lib${package}",
@@ -39,7 +35,7 @@ class php::embedded(
   }->
   ::php::config { 'embedded':
     file   => $inifile,
-    config => $real_settings,
+    config => $settings,
   }
   
 }

--- a/manifests/fpm.pp
+++ b/manifests/fpm.pp
@@ -26,7 +26,6 @@ class php::fpm (
   validate_hash($settings)
   validate_hash($pools)
 
-  $real_settings = deep_merge($settings, hiera_hash('php::fpm::settings', {}))
 
   # On FreeBSD fpm is not a separate package, but included in the 'php' package.
   # Implies that the option SET+=FPM was set when building the port.
@@ -42,13 +41,12 @@ class php::fpm (
     } ->
     class { '::php::fpm::config':
       inifile  => $inifile,
-      settings => $real_settings,
+      settings => $settings,
     } ->
     class { '::php::fpm::service': } ->
   anchor { '::php::fpm::end': }
 
-  $real_pools = hiera_hash('php::fpm::pools',  $pools)
-  create_resources(::php::fpm::pool, $real_pools)
+  create_resources(::php::fpm::pool, $pools)
 
   # Create an override to use a reload signal as trusty and utopic's
   # upstart version supports this

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -60,12 +60,6 @@ class php (
   validate_hash($extensions)
   validate_hash($settings)
 
-  # Deep merge global php settings
-  $real_settings = deep_merge($settings, hiera_hash('php::settings', {}))
-
-  # Deep merge global php extensions
-  $real_extensions = deep_merge($extensions, hiera_hash('php::extensions', {}))
-
   if $manage_repos {
     class { '::php::repo': } ->
     Anchor['php::begin']
@@ -74,14 +68,14 @@ class php (
   anchor { 'php::begin': } ->
     class { '::php::packages': } ->
     class { '::php::cli':
-      settings => $real_settings,
+      settings => $settings,
     } ->
   anchor { 'php::end': }
 
   if $fpm {
     Anchor['php::begin'] ->
       class { '::php::fpm':
-        settings => $real_settings,
+        settings => $settings,
       } ->
     Anchor['php::end']
   }
@@ -93,7 +87,7 @@ class php (
     
     Anchor['php::begin'] ->
       class { '::php::embedded':
-        settings => $real_settings,
+        settings => $settings,
       } ->
     Anchor['php::end']
   }
@@ -120,7 +114,7 @@ class php (
     Anchor['php::end']
   }
 
-  create_resources('::php::extension', $real_extensions, {
+  create_resources('::php::extension', $extensions, {
     require => Class['::php::cli'],
     before  => Anchor['php::end']
   })

--- a/metadata.json
+++ b/metadata.json
@@ -7,7 +7,7 @@
   "source": "https://github.com/mayflower/puppet-php",
   "project_page": "http://php.puppet.mayflower.de/",
   "issues_url": "https://github.com/mayflower/puppet-php/issues",
-  "description": "Puppet module that aims to manage PHP and extensions in a generic way on many platforms with sane defaults and easy, hiera-centric configuration",
+  "description": "Puppet module that aims to manage PHP and extensions in a generic way on many platforms with sane defaults and easy configuration",
   "dependencies": [
     { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.2.0 < 5.0.0" },
     { "name": "puppetlabs/apt", "version_requirement": ">= 1.8.0 < 3.0.0" },


### PR DESCRIPTION
This PR resolves https://github.com/mayflower/puppet-php/issues/118. In a nutshell: this module used to depend heavily on Hiera and broke some best practice rules for puppet module design. Much of the groundwork to remove the Hiera dependency has already been done with previous PRs, and I now propose this PR to finally remove any `hiera` or `hiera_hash` lookups from the manifest code, and to make better documentation for proper example usage of Puppet's DSL code.

It includes:
  1. Updated `README.md`: Removed references of hiera data examples and replaced them with examples of Puppet DSL code.
  1. Updated `README.md`: Rearranged/reworded a few areas for better grammar, etc.
  1. Updated `README.md`: Given the Hiera-ish history of this module, I included a section for proper usage of Hiera given today's best practices.
  1. Updated manifests to not have `hiera` or `hiera_hash` lookups.

Please double check my work and let me know if it needs any adjustments, thanks!