### PR TITLE
Add options to fpm config and pool configs

### DIFF
--- a/manifests/fpm/config.pp
+++ b/manifests/fpm/config.pp
@@ -40,6 +40,12 @@
 # [*process_control_timeout*]
 #   The php-fpm process_control_timeout
 #
+# [*process_max*]
+#   The maximum number of processes FPM will fork.
+#
+# [*rlimit_files*]
+#   Set open file descriptor rlimit for the master process.
+#
 # [*systemd_interval*]
 #   The interval between health report notification to systemd
 #
@@ -72,6 +78,8 @@ class php::fpm::config(
   $emergency_restart_threshold = '0',
   $emergency_restart_interval  = '0',
   $process_control_timeout     = '0',
+  $process_max                 = '0',
+  $rlimit_files                = undef,
   $systemd_interval            = undef,
   $log_owner                   = $::php::params::fpm_user,
   $log_group                   = $::php::params::fpm_group,

--- a/manifests/fpm/pool.pp
+++ b/manifests/fpm/pool.pp
@@ -112,6 +112,8 @@ define php::fpm::pool (
   $pm_status_path = undef,
   $ping_path = undef,
   $ping_response = 'pong',
+  $access_log = undef,
+  $access_log_format = "%R - %u %t \"%m %r\" %s",
   $request_terminate_timeout = '0',
   $request_slowlog_timeout = '0',
   $security_limit_extensions = undef,

--- a/manifests/fpm/pool.pp
+++ b/manifests/fpm/pool.pp
@@ -48,6 +48,12 @@
 #
 # [*ping_reponse*]
 #
+# [*access_log*]
+#   The path to the file to write access log requests to
+#
+# [*access_log_format*]
+#   The format to save the access log entries as
+#
 # [*request_terminate_timeout*]
 #
 # [*request_slowlog_timeout*]

--- a/templates/fpm/php-fpm.conf.erb
+++ b/templates/fpm/php-fpm.conf.erb
@@ -74,7 +74,7 @@ process_control_timeout = <%= @process_control_timeout %>
 ; Use it with caution.
 ; Note: A value of 0 indicates no limit
 ; Default Value: 0
-; process.max = 128
+process.max = <%= @process_max %>
 
 ; Specify the nice(2) priority to apply to the master process (only if set)
 ; The value can vary from -19 (highest priority) to 20 (lower priority)
@@ -90,7 +90,11 @@ process_control_timeout = <%= @process_control_timeout %>
 
 ; Set open file descriptor rlimit for the master process.
 ; Default Value: system defined value
+<% if @rlimit_files -%>
+rlimit_files = <%= @rlimit_files %>
+<% else -%>
 ;rlimit_files = 1024
+<% end -%>
 
 ; Set max core size rlimit for the master process.
 ; Possible Values: 'unlimited' or an integer greater or equal to 0

--- a/templates/fpm/pool.conf.erb
+++ b/templates/fpm/pool.conf.erb
@@ -156,7 +156,7 @@ ping.response = <%= @ping_response %>
 ; Default: not set
 <% if @access_log -%>
 access.log = <%= @access_log %>
-<$ end -%>
+<% end -%>
 
 ; The access log format.
 ; The following syntax is allowed

--- a/templates/fpm/pool.conf.erb
+++ b/templates/fpm/pool.conf.erb
@@ -152,6 +152,67 @@ ping.path = <%= @ping_path %>
 ; Default Value: pong
 ping.response = <%= @ping_response %>
 
+; The access log file
+; Default: not set
+<% if @access_log -%>
+access.log = <%= @access_log %>
+<$ end -%>
+
+; The access log format.
+; The following syntax is allowed
+;  %%: the '%' character
+;  %C: %CPU used by the request
+;      it can accept the following format:
+;      - %{user}C for user CPU only
+;      - %{system}C for system CPU only
+;      - %{total}C  for user + system CPU (default)
+;  %d: time taken to serve the request
+;      it can accept the following format:
+;      - %{seconds}d (default)
+;      - %{miliseconds}d
+;      - %{mili}d
+;      - %{microseconds}d
+;      - %{micro}d
+;  %e: an environment variable (same as $_ENV or $_SERVER)
+;      it must be associated with embraces to specify the name of the env
+;      variable. Some exemples:
+;      - server specifics like: %{REQUEST_METHOD}e or %{SERVER_PROTOCOL}e
+;      - HTTP headers like: %{HTTP_HOST}e or %{HTTP_USER_AGENT}e
+;  %f: script filename
+;  %l: content-length of the request (for POST request only)
+;  %m: request method
+;  %M: peak of memory allocated by PHP
+;      it can accept the following format:
+;      - %{bytes}M (default)
+;      - %{kilobytes}M
+;      - %{kilo}M
+;      - %{megabytes}M
+;      - %{mega}M
+;  %n: pool name
+;  %o: ouput header
+;      it must be associated with embraces to specify the name of the header:
+;      - %{Content-Type}o
+;      - %{X-Powered-By}o
+;      - %{Transfert-Encoding}o
+;      - ....
+;  %p: PID of the child that serviced the request
+;  %P: PID of the parent of the child that serviced the request
+;  %q: the query string
+;  %Q: the '?' character if query string exists
+;  %r: the request URI (without the query string, see %q and %Q)
+;  %R: remote IP address
+;  %s: status (response code)
+;  %t: server time the request was received
+;      it can accept a strftime(3) format:
+;      %d/%b/%Y:%H:%M:%S %z (default)
+;  %T: time the log has been written (the request has finished)
+;      it can accept a strftime(3) format:
+;      %d/%b/%Y:%H:%M:%S %z (default)
+;  %u: remote user
+;
+; Default: "%R - %u %t \"%m %r\" %s"
+access.format = <%= @access_log_format %>
+
 ; The timeout for serving a single request after which the worker process will
 ; be killed. This option should be used when the 'max_execution_time' ini option
 ; does not stop script execution for some reason. A value of '0' means 'off'.


### PR DESCRIPTION
We manage a couple configuration options that aren't set in the current templates. Added the following options:

In php-fpm.conf, you can now modify process.max, and rlimit_files at this global level.

In the pool template, you can now modify the access log path and format.