### PR TITLE
test Ruby 2.2 and Puppet 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
 - 1.9.3
 env:
   matrix:
+  - PUPPET_VERSION=4.3.1
   - PUPPET_VERSION=3.8.4
   - PUPPET_VERSION=3.8.4 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
   global:
@@ -17,6 +18,8 @@ matrix:
   include:
   - rvm: 2.1.6
     env: PUPPET_VERSION=3.8.4 DOCS=true
+  - rvm: 2.2.3
+    env: PUPPET_VERSION=4.3.1
 after_success: |
   [ $TRAVIS_BRANCH = master ] &&
   [ $TRAVIS_PULL_REQUEST = false ] &&

--- a/metadata.json
+++ b/metadata.json
@@ -16,8 +16,8 @@
     { "name": "example42/yum", "version_requirement": "2.x" }
   ],
   "requirements": [
-    { "name": "puppet", "version_requirement": "3.x" },
-    { "name": "pe", "version_requirement": "3.x" }
+    { "name": "puppet", "version_requirement": ">= 3.0.0 < 5.0.0" },
+    { "name": "pe", "version_requirement": ">= 3.0.0" }
   ],
   "operatingsystem_support": [
     { "operatingsystem": "Ubuntu",


### PR DESCRIPTION
Ruby 2.2 is only supported with Puppet 4.x. The PE version_requirement is open ended for now because of the 2015.x.x thing...