### PR TITLE
Fixes non-overridable paths

### DIFF
--- a/manifests/extension.pp
+++ b/manifests/extension.pp
@@ -168,18 +168,21 @@ define php::extension(
     }
   }
 
+  $config_root_ini = pick_default($::php::config_root_ini, $::php::params::config_root_ini)
   ::php::config { $title:
-    file   => "${::php::params::config_root_ini}/${lowercase_title}.ini",
+    file   => "${config_root_ini}/${lowercase_title}.ini",
     config => $final_settings,
   }
 
   # Ubuntu/Debian systems use the mods-available folder. We need to enable
   # settings files ourselves with php5enmod command.
+  $ext_tool_enable = pick_default($::php::ext_tool_enable, $::php::params::ext_tool_enable)
+  $ext_tool_query  = pick_default($::php::ext_tool_query, $::php::params::ext_tool_query)
   if $::osfamily == 'Debian' {
-    $cmd = "/usr/sbin/php5enmod ${lowercase_title}"
+    $cmd = "${ext_tool_enable} ${lowercase_title}"
 
     exec { $cmd:
-      unless  => "/usr/sbin/php5query -s cli -m ${lowercase_title}",
+      unless  => "${ext_tool_query} -s cli -m ${lowercase_title}",
       require =>::Php::Config[$title],
     }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,6 +33,19 @@
 #   to a sensible default depending on your operating system, like 'php-' or
 #   'php5-'.
 #
+# [*config_root_ini*]
+#   This is the path to the config .ini files of the extensions. This defaults
+#   to a sensible default depending on your operating system, like
+#   '/etc/php5/mods-available' or '/etc/php5/conf.d'.
+#
+# [*$ext_tool_enable*]
+#   Absolute path to php tool for enabling extensions in debian/ubuntu systems.
+#   This defaults to '/usr/sbin/php5enmod'.
+#
+# [*$ext_tool_query*]
+#   Absolute path to php tool for querying information about extensions in
+#   debian/ubuntu systems. This defaults to '/usr/sbin/php5query'.
+#
 class php (
   $ensure         = $::php::params::ensure,
   $manage_repos   = $::php::params::manage_repos,
@@ -46,6 +59,9 @@ class php (
   $extensions     = {},
   $settings       = {},
   $package_prefix = $::php::params::package_prefix,
+  $config_root_ini = $::php::params::config_root_ini,
+  $ext_tool_enable = $::php::params::ext_tool_enable,
+  $ext_tool_query  = $::php::params::ext_tool_query,
 ) inherits ::php::params {
 
   validate_string($ensure)
@@ -59,6 +75,15 @@ class php (
   validate_bool($phpunit)
   validate_hash($extensions)
   validate_hash($settings)
+  if $config_root_ini != undef {
+    validate_absolute_path($config_root_ini)
+  }
+  if $ext_tool_enable != undef {
+    validate_absolute_path($ext_tool_enable)
+  }
+  if $ext_tool_query != undef {
+    validate_absolute_path($ext_tool_query)
+  }
 
   # Deep merge global php settings
   $real_settings = deep_merge($settings, hiera_hash('php::settings', {}))

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,6 +1,12 @@
 # PHP params class
 #
-class php::params {
+class php::params(
+  $cfg_root = undef,
+) {
+
+  if $cfg_root != undef {
+    validate_absolute_path($cfg_root)
+  }
 
   $ensure              = 'present'
   $fpm_service_enable  = true
@@ -15,8 +21,8 @@ class php::params {
 
   case $::osfamily {
     'Debian': {
-      $config_root             = '/etc/php5'
-      $config_root_ini         = "${::php::params::config_root}/mods-available"
+      $config_root             = pick($cfg_root, '/etc/php5')
+      $config_root_ini         = "${config_root}/mods-available"
       $common_package_names    = []
       $common_package_suffixes = ['cli', 'common']
       $cli_inifile             = "${config_root}/cli/php.ini"
@@ -35,6 +41,8 @@ class php::params {
       $package_prefix          = 'php5-'
       $compiler_packages       = 'build-essential'
       $root_group              = 'root'
+      $ext_tool_enable         = '/usr/sbin/php5enmod'
+      $ext_tool_query          = '/usr/sbin/php5query'
 
       case $::operatingsystem {
         'Debian': {
@@ -52,7 +60,7 @@ class php::params {
     }
 
     'Suse': {
-      $config_root             = '/etc/php5'
+      $config_root             = pick($cfg_root, '/etc/php5')
       $config_root_ini         = "${config_root}/conf.d"
       $common_package_names    = ['php5']
       $common_package_suffixes = []
@@ -107,7 +115,7 @@ class php::params {
       $root_group              = 'root'
     }
     'FreeBSD': {
-      $config_root             = '/usr/local/etc'
+      $config_root             = pick($cfg_root, '/usr/local/etc')
       $config_root_ini         = "${config_root}/php"
       # No common packages, because the required PHP base package will be
       # pulled in as a dependency. This preserves the ability to choose

--- a/spec/defines/extension_spec.rb
+++ b/spec/defines/extension_spec.rb
@@ -141,7 +141,7 @@ describe 'php::extension' do
 
             it {
               should contain_php__config('xdebug').with({
-                :file => '/etc/php5/mods-available/xdebug.ini',
+                :file => "#{etcdir}/xdebug.ini",
               })
             }
             context 'pecl installation' do


### PR DESCRIPTION
When I have tried to install the recently released PHP 7.0.0, I have come across some issues:

1. The path for FPM pool conf files are built with `$::php::params::fpm_pool_dir` instead of `$::php::fpm::config::pool_base_dir`. This makes impossible to override the path of these files, but this path can be overriden with previous parameter from class `php::fpm::config`, and that path should be used because the pools belong to FPM and should use its base dir.
2. The path for PHP extensions ini files are built with `$::php::params::config_root_ini`, and we have the same previous problem: it is impossible to override that path. This should be a parameter from the defined type `php::extension`, but it would not be *hierable* due to the intrinsic nature of the defined type. The best approach I have come along is adding a new parameter `$::php::config_root_ini` to class `php` (at `manifests/init.pp`), so it becomes tuneable through manifests and Hiera also.
3. `php5enmod` and `php5query` commands in debian/ubuntu becomes `phpenmod` and `phpquery` with PHP 7, so the module fails to enable the requested extensions in those systems. The path to those tools could be added as parameter of the defined type `php::extension`, but, as it is a global command for the machine, I think it should be in the main class `php` at `init.pp`, where I have added them. I have added their defaults in `php::params`, so they inherit properly the default values when not provided.
4. All paths can be easily changed if a new param `$::php::params::cfg_root` is added to `php::params`.

So firstly I used the following Hiera setup to get PHP 7 working in my ubuntu virtual machine:

```
php::cli::inifile: '/etc/php/7.0/cli/php.ini'
php::extensions:
  'xdebug':
    ensure: '2.4.0RC3'
    provider: 'pecl'
php::fpm::config::config_file: '/etc/php/7.0/fpm/php-fpm.conf'
php::fpm::config::error_log: '/var/log/php7.0-fpm.log'
php::fpm::config::inifile: '/etc/php/7.0/fpm/php.ini'
php::fpm::config::pid_file: '/var/run/php/php7.0-fpm.pid'
php::fpm::config::pool_base_dir: '/etc/php/7.0/fpm/pool.d'
php::fpm::inifile: '/etc/php/7.0/fpm/php.ini'
php::fpm::service::service_name: 'php7.0-fpm'
php::fpm::pools:
  'www':
    listen: '/var/run/php/php7.0-fpm.sock'
php::package_prefix: 'php7.0-'
php::repo::ubuntu::ppa: 'ondrej/php-7.0'
```


But then:

* **1** forced pool to be at '/etc/php5/fpm/pool.d/www', but it should be at '/etc/php/7.0/fpm/pool.d/www'. After applying, the pull request fixes issue **1** it and the module works as expected.
* **2** forced `xdebug` extension conf file to be at `'/etc/php5/mods-available/xdebug.ini'`, but it should be at `'etc/php/7.0/mods-available/xdebug.ini'`. After applying, the pull request fixes issue **2** and the module works as expected.
* **3** fired puppet error `Could not find command '/usr/sbin/php5query'` or `Could not find command '/usr/sbin/php5enmod'`. After applying, the pull request fixes **3** and the module works as expected.
* after applying the pull request, hiera setup becomes easier and shorter.

After applying the pull request, the Hiera code becomes:

```
php::extensions:
  'xdebug':
    ensure: '2.4.0RC3'
    provider: 'pecl'
php::fpm::config::error_log: '/var/log/php7.0-fpm.log'
php::fpm::config::pid_file: '/var/run/php/php7.0-fpm.pid'
php::fpm::service::service_name: 'php7.0-fpm'
php::fpm::pools:
  'www':
    listen: '/var/run/php/php7.0-fpm.sock'
php::package_prefix: 'php7.0-'
php::params::config_root: '/etc/php/7.0'
php::repo::ubuntu::ppa: 'ondrej/php-7.0'
```

I have only tested this in Ubuntu 14.04, but the changes proposed in the pull request should not introduce errors in any other system. Finally, the pull request makes the module much more customizable.

Resolves #146 