### PR TITLE
Fix for  php 5.6 on Centos 7.1.1503 #131 

### DIFF
--- a/manifests/repo/redhat.pp
+++ b/manifests/repo/redhat.pp
@@ -10,4 +10,5 @@ class php::repo::redhat (
   $yum_repo = 'remi_php56',
 ) {
   contain "::yum::repo::${yum_repo}"
+  contain "::yum::repo::remi"
 }

--- a/manifests/repo/redhat.pp
+++ b/manifests/repo/redhat.pp
@@ -10,5 +10,5 @@ class php::repo::redhat (
   $yum_repo = 'remi_php56',
 ) {
   contain "::yum::repo::${yum_repo}"
-  contain "::yum::repo::remi"
+  contain '::yum::repo::remi'
 }


### PR DESCRIPTION
have added the yum repo so this works ok on centos7 - not sure if i should leave the original reference in so have left it. 