### PR TITLE
class uses 'pools' hiera key, not 'pool'

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ php::extensions:
     settings:
       'apc/stat': 1
       'apc/stat_ctime': 1
-php::fpm::pool:
+php::fpm::pools:
   www2:
     listen: '127.0.1.1:9000'
 ```


### PR DESCRIPTION
either module has to be changed or the documentation.
I would change module instead, since it's not intuitive, but this would create an incompatibility with current configurations

