### PR TITLE
Enable/Disable $ext_tool Debian

### DIFF
--- a/manifests/extension.pp
+++ b/manifests/extension.pp
@@ -176,9 +176,11 @@ define php::extension(
 
   # Ubuntu/Debian systems use the mods-available folder. We need to enable
   # settings files ourselves with php5enmod command.
-  $ext_tool_enable = pick_default($::php::ext_tool_enable, $::php::params::ext_tool_enable)
-  $ext_tool_query  = pick_default($::php::ext_tool_query, $::php::params::ext_tool_query)
-  if $::osfamily == 'Debian' {
+  $ext_tool_enable   = pick_default($::php::ext_tool_enable, $::php::params::ext_tool_enable)
+  $ext_tool_query    = pick_default($::php::ext_tool_query, $::php::params::ext_tool_query)
+  $ext_tool_enabled  = pick_default($::php::ext_tool_enabled, $::php::params::ext_tool_enabled)
+
+  if $::osfamily == 'Debian' and $ext_tool_enabled {
     $cmd = "${ext_tool_enable} ${lowercase_title}"
 
     exec { $cmd:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,6 +56,10 @@
 #   Absolute path to php tool for querying information about extensions in
 #   debian/ubuntu systems. This defaults to '/usr/sbin/php5query'.
 #
+# [*$ext_tool_enabled*]
+#   Enable or disable the use of php tools on debian based systems
+#   debian/ubuntu systems. This defaults to 'true'.
+#
 # [*log_owner*]
 #   The php-fpm log owner
 #
@@ -82,6 +86,7 @@ class php (
   $config_root_ini    = $::php::params::config_root_ini,
   $ext_tool_enable    = $::php::params::ext_tool_enable,
   $ext_tool_query     = $::php::params::ext_tool_query,
+  $ext_tool_enabled   = $::php::params::ext_tool_enabled,
   $log_owner          = $::php::params::fpm_user,
   $log_group          = $::php::params::fpm_group,
 ) inherits ::php::params {
@@ -93,6 +98,7 @@ class php (
   validate_bool($dev)
   validate_bool($composer)
   validate_bool($pear)
+  validate_bool($ext_tool_enabled)
   validate_string($pear_ensure)
   validate_bool($phpunit)
   validate_hash($extensions)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -45,6 +45,7 @@ class php::params(
       $root_group              = 'root'
       $ext_tool_enable         = '/usr/sbin/php5enmod'
       $ext_tool_query          = '/usr/sbin/php5query'
+      $ext_tool_enabled        = true
 
       case $::operatingsystem {
         'Debian': {
@@ -83,6 +84,7 @@ class php::params(
       $package_prefix          = 'php5-'
       $manage_repos            = true
       $root_group              = 'root'
+      $ext_tool_enabled        = false
       case $::operatingsystem {
         'SLES': {
           $compiler_packages = []
@@ -117,6 +119,7 @@ class php::params(
       $compiler_packages       = ['gcc', 'gcc-c++', 'make']
       $manage_repos            = false
       $root_group              = 'root'
+      $ext_tool_enabled        = false
     }
     'FreeBSD': {
       $config_root             = pick($cfg_root, '/usr/local/etc')
@@ -144,6 +147,7 @@ class php::params(
       $compiler_packages       = ['gcc']
       $manage_repos            = false
       $root_group              = 'wheel'
+      $ext_tool_enabled        = false
     }
     default: {
       fail("Unsupported osfamily: ${::osfamily}")

--- a/manifests/repo/ubuntu.pp
+++ b/manifests/repo/ubuntu.pp
@@ -17,10 +17,10 @@ class php::repo::ubuntu (
   validate_re($version, '^\d\.\d')
 
   $version_repo = $version ? {
-    '5.4' => 'ondrej/php5-oldstable'
-    '5.5' => 'ondrej/php5'
-    '5.6' => 'ondrej/php5-5.6'
-    '7.0' => 'ondrej/php-7.0'
+    '5.4' => 'ondrej/php5-oldstable',
+    '5.5' => 'ondrej/php5',
+    '5.6' => 'ondrej/php5-5.6',
+    '7.0' => 'ondrej/php'
   }
 
   if ($ppa and $version == true) {


### PR DESCRIPTION
This fixes some issues with php7 and php5enmod/php5query on at least Ubuntu, but i assume it would also work on debian. 

Also switched to non deprecated php 7 repo. 