### PR TITLE
Add '/usr/local' paths to support FreeBSD

### DIFF
--- a/manifests/composer/auto_update.pp
+++ b/manifests/composer/auto_update.pp
@@ -31,7 +31,7 @@ class php::composer::auto_update (
   exec { 'update composer':
     command => "wget ${source} -O ${path}",
     onlyif  => "test `find '${path}' -mtime +${max_age}`",
-    path    => [ '/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/' ],
+    path    => [ '/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/', '/usr/local/bin', '/usr/local/sbin' ],
     require => File[$path],
   }
 }


### PR DESCRIPTION
FreeBSD installs all software from a package manager into `/usr/local`.
This includes the `wget` binary, which is included in the `pkg` package manager.

OSX will probably also benefit from this when `wget` is installed using Homebrew.