### PR TITLE
Add third argument 'global_pool_settings' for resource ::php::fpm::pool.

### DIFF
--- a/manifests/fpm.pp
+++ b/manifests/fpm.pp
@@ -34,17 +34,22 @@
 # [*settings*]
 #   fpm settings hash
 #
+# [*global_pool_settings*]
+#   Hash of defaults params php::fpm::pool resources that will be created.
+#   Defaults is empty hash.
+#
 class php::fpm (
-  $ensure         = $::php::ensure,
-  $service_ensure = $::php::params::fpm_service_ensure,
-  $service_enable = $::php::params::fpm_service_enable,
-  $service_name   = $::php::params::fpm_service_name,
-  $package        = "${::php::package_prefix}${::php::params::fpm_package_suffix}",
-  $inifile        = $::php::params::fpm_inifile,
-  $settings       = {},
-  $pools          = { 'www' => {} },
-  $log_owner      = $::php::params::fpm_user,
-  $log_group      = $::php::params::fpm_group
+  $ensure               = $::php::ensure,
+  $service_ensure       = $::php::params::fpm_service_ensure,
+  $service_enable       = $::php::params::fpm_service_enable,
+  $service_name         = $::php::params::fpm_service_name,
+  $package              = "${::php::package_prefix}${::php::params::fpm_package_suffix}",
+  $inifile              = $::php::params::fpm_inifile,
+  $settings             = {},
+  $global_pool_settings = {},
+  $pools                = { 'www' => {} },
+  $log_owner            = $::php::params::fpm_user,
+  $log_group            = $::php::params::fpm_group
 ) inherits ::php::params {
 
   if $caller_module_name != $module_name {
@@ -84,8 +89,9 @@ class php::fpm (
     } ->
   anchor { '::php::fpm::end': }
 
+  $real_global_pool_settings = hiera_hash('php::fpm::global_pool_settings', $global_pool_settings)
   $real_pools = hiera_hash('php::fpm::pools',  $pools)
-  create_resources(::php::fpm::pool, $real_pools)
+  create_resources(::php::fpm::pool, $real_pools, $real_global_pool_settings)
 
   # Create an override to use a reload signal as trusty and utopic's
   # upstart version supports this


### PR DESCRIPTION
Parameter $global_pool_settings for class ::php::fpm realize feature default global settings for all fpm pools.
Not used parameter (hiera example):
```
php::fpm::pools:
   first_pool:
     pm_min_spare_servers: '5'
     pm_max_spare_servers: '35'
     pm_max_requests: '2048'
     ping_response: 'pong'
     request_terminate_timeout: '120'
     request_slowlog_timeout: '30'
     rlimit_files: '2048'
     catch_workers_output: 'no'
   second_pool:
     pm_min_spare_servers: '10'
     pm_max_spare_servers: '35'
     pm_max_requests: '2048'
     ping_response: 'pong'
     request_terminate_timeout: '120'
     request_slowlog_timeout: '30'
     rlimit_files: '2048'
     catch_workers_output: 'no'
```
Used parameter (hiera example):
```
php::fpm::global_pool_settings:
  pm_max_spare_servers: '35'
  pm_max_requests: '2048'
  ping_response: 'pong'
  request_terminate_timeout: '120'
  request_slowlog_timeout: '30'
  rlimit_files: '2048'
  catch_workers_output: 'no'
php::fpm::pools:
  first_pool:
    pm_min_spare_servers: '5'
  second_pool:
    pm_min_spare_servers: '10'
```