### PR TITLE
Allow specifying the sapi for debian/ubuntu systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ activated for all activated SAPIs.
           'apc/stat'       => '1',
           'apc/stat_ctime' => '1',
         },
+        sapi     => 'fpm',
       },
       
     },
@@ -148,6 +149,7 @@ php::extensions:
     settings:
       'apc/stat': 1
       'apc/stat_ctime': 1
+    sapi: 'fpm'
 php::fpm::pools:
   www2:
     listen: '127.0.1.1:9000'

--- a/manifests/extension.pp
+++ b/manifests/extension.pp
@@ -189,9 +189,16 @@ define php::extension(
   if $::osfamily == 'Debian' and $ext_tool_enabled {
     $cmd = "${ext_tool_enable} -s ${sapi} ${lowercase_title}"
 
-    exec { $cmd:
-      unless  => "${ext_tool_query} -s cli -m ${lowercase_title}",
-      require =>::Php::Config[$title],
+    if $sapi == 'ALL' {
+      exec { $cmd:
+        unless  => "${ext_tool_query} -s cli -m ${lowercase_title}",
+        require =>::Php::Config[$title],
+      }
+    } else {
+      exec { $cmd:
+        unless  => "${ext_tool_query} -s ${sapi} -m ${lowercase_title}",
+        require =>::Php::Config[$title],
+      }
     }
 
     if $::php::fpm {

--- a/manifests/extension.pp
+++ b/manifests/extension.pp
@@ -48,6 +48,10 @@
 #   Boolean/String parameter, whether to prefix all setting keys with
 #   the extension name or specified name. Defaults to false.
 #
+# [*sapi*]
+#   String parameter, whether to specify ALL sapi or a specific sapi.
+#   Defaults to ALL.
+#
 define php::extension(
   $ensure            = 'installed',
   $provider          = undef,

--- a/manifests/extension.pp
+++ b/manifests/extension.pp
@@ -61,12 +61,14 @@ define php::extension(
   $zend              = false,
   $settings          = {},
   $settings_prefix   = false,
+  $sapi              = 'ALL',
 ) {
 
   validate_string($ensure)
   validate_string($package_prefix)
   validate_string($so_name)
   validate_string($php_api_version)
+  validate_string($sapi)
   validate_array($header_packages)
   validate_bool($zend)
 
@@ -185,10 +187,10 @@ define php::extension(
   $ext_tool_enabled  = pick_default($::php::ext_tool_enabled, $::php::params::ext_tool_enabled)
 
   if $::osfamily == 'Debian' and $ext_tool_enabled {
-    $cmd = "${ext_tool_enable} ${lowercase_title}"
+    $cmd = "${ext_tool_enable} -s ${sapi} ${lowercase_title}"
 
     exec { $cmd:
-      unless  => "${ext_tool_query} -s cli -m ${lowercase_title}",
+      unless  => "${ext_tool_query} -s ${sapi} -m ${lowercase_title}",
       require =>::Php::Config[$title],
     }
 

--- a/manifests/extension.pp
+++ b/manifests/extension.pp
@@ -190,7 +190,7 @@ define php::extension(
     $cmd = "${ext_tool_enable} -s ${sapi} ${lowercase_title}"
 
     exec { $cmd:
-      unless  => "${ext_tool_query} -s ${sapi} -m ${lowercase_title}",
+      unless  => "${ext_tool_query} -s cli -m ${lowercase_title}",
       require =>::Php::Config[$title],
     }
 


### PR DESCRIPTION
This patch enables specifying a specific sapi to the php5enmod executor. Some extensions (i.e. php5-suhosin-extension) are undesirable for the cli sapi, and this enables specifying only fpm.