### PR TITLE
allow for class to be defined and pass a pid file path

### DIFF
--- a/manifests/fpm.pp
+++ b/manifests/fpm.pp
@@ -49,7 +49,7 @@ class php::fpm (
   $global_pool_settings = {},
   $pools                = { 'www' => {} },
   $log_owner            = $::php::params::fpm_user,
-  $log_group            = $::php::params::fpm_group
+  $log_group            = $::php::params::fpm_group,
   $pid_file             = $::php::params::fpm_pid_file
 ) inherits ::php::params {
 

--- a/manifests/fpm.pp
+++ b/manifests/fpm.pp
@@ -34,6 +34,9 @@
 # [*settings*]
 #   fpm settings hash
 #
+# [*pid_file*]
+#   Path to pid file for fpm
+#
 # [*global_pool_settings*]
 #   Hash of defaults params php::fpm::pool resources that will be created.
 #   Defaults is empty hash.
@@ -60,6 +63,7 @@ class php::fpm (
   validate_string($ensure)
   validate_string($package)
   validate_absolute_path($inifile)
+  validate_absolute_path($pid_file)
   validate_hash($settings)
   validate_hash($pools)
 

--- a/manifests/fpm.pp
+++ b/manifests/fpm.pp
@@ -12,7 +12,7 @@
 #   This is the name of the php-fpm service. It defaults to reasonable OS
 #   defaults but can be different in case of using php7.0/other OS/custom fpm service
 #
-#   [*service_provider*]
+# [*service_provider*]
 #   This is the name of the service provider, in case there is a non
 #   OS default service provider used to start FPM.
 #   Defaults to 'undef', pick system defaults.
@@ -56,7 +56,6 @@ class php::fpm (
   $pools                = { 'www' => {} },
   $log_owner            = $::php::params::fpm_user,
   $log_group            = $::php::params::fpm_group,
-  $pid_file             = $::php::params::fpm_pid_file
 ) inherits ::php::params {
 
   if $caller_module_name != $module_name {
@@ -88,7 +87,6 @@ class php::fpm (
       settings  => $real_settings,
       log_owner => $log_owner,
       log_group => $log_group,
-      pid_file  => $pid_file,
     } ->
     class { '::php::fpm::service':
       ensure       => $service_ensure,

--- a/manifests/fpm.pp
+++ b/manifests/fpm.pp
@@ -34,9 +34,6 @@
 # [*settings*]
 #   fpm settings hash
 #
-# [*pid_file*]
-#   Path to pid file for fpm
-#
 # [*global_pool_settings*]
 #   Hash of defaults params php::fpm::pool resources that will be created.
 #   Defaults is empty hash.
@@ -63,7 +60,6 @@ class php::fpm (
   validate_string($ensure)
   validate_string($package)
   validate_absolute_path($inifile)
-  validate_absolute_path($pid_file)
   validate_hash($settings)
   validate_hash($pools)
 

--- a/manifests/fpm.pp
+++ b/manifests/fpm.pp
@@ -50,6 +50,7 @@ class php::fpm (
   $pools                = { 'www' => {} },
   $log_owner            = $::php::params::fpm_user,
   $log_group            = $::php::params::fpm_group
+  $pid_file             = $::php::params::fpm_pid_file
 ) inherits ::php::params {
 
   if $caller_module_name != $module_name {
@@ -81,6 +82,7 @@ class php::fpm (
       settings  => $real_settings,
       log_owner => $log_owner,
       log_group => $log_group,
+      pid_file  => $pid_file,
     } ->
     class { '::php::fpm::service':
       ensure       => $service_ensure,

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -8,6 +8,10 @@
 # [*config_root*]
 #   The configuration root directory.
 #
+# [*fpm_pid_file*]
+#   Path to pid file for fpm
+#
+
 class php::globals (
   $php_version = undef,
   $config_root = undef,

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -10,11 +10,10 @@
 #
 # [*fpm_pid_file*]
 #   Path to pid file for fpm
-#
 
 class php::globals (
-  $php_version = undef,
-  $config_root = undef,
+  $php_version  = undef,
+  $config_root  = undef,
   $fpm_pid_file = undef,
 ) {
   if $php_version != undef {
@@ -46,70 +45,70 @@ class php::globals (
       if $::operatingsystem == 'Ubuntu' {
         case $globals_php_version {
           /^5\.4/: {
-            $default_config_root = '/etc/php5'
+            $default_config_root  = '/etc/php5'
             $default_fpm_pid_file = "/var/run/php/php${globals_php_version}-fpm.pid"
-            $fpm_error_log       = '/var/log/php5-fpm.log'
-            $fpm_service_name    = 'php5-fpm'
-            $ext_tool_enable     = '/usr/sbin/php5enmod'
-            $ext_tool_query      = '/usr/sbin/php5query'
-            $package_prefix      = 'php5-'
+            $fpm_error_log        = '/var/log/php5-fpm.log'
+            $fpm_service_name     = 'php5-fpm'
+            $ext_tool_enable      = '/usr/sbin/php5enmod'
+            $ext_tool_query       = '/usr/sbin/php5query'
+            $package_prefix       = 'php5-'
           }
           /^5\.5/: {
-            $default_config_root = "/etc/php/${globals_php_version}"
+            $default_config_root  = "/etc/php/${globals_php_version}"
             $default_fpm_pid_file = "/var/run/php/php${globals_php_version}-fpm.pid"
-            $fpm_error_log       = "/var/log/php${globals_php_version}-fpm.log"
-            $fpm_service_name    = "php${globals_php_version}-fpm"
-            $ext_tool_enable     = "/usr/sbin/phpenmod -v ${globals_php_version}"
-            $ext_tool_query      = "/usr/sbin/phpquery -v ${globals_php_version}"
-            $package_prefix      = 'php5.5-'
+            $fpm_error_log        = "/var/log/php${globals_php_version}-fpm.log"
+            $fpm_service_name     = "php${globals_php_version}-fpm"
+            $ext_tool_enable      = "/usr/sbin/phpenmod -v ${globals_php_version}"
+            $ext_tool_query       = "/usr/sbin/phpquery -v ${globals_php_version}"
+            $package_prefix       = 'php5.5-'
           }
           /^5\.6/: {
-            $default_config_root = "/etc/php/${globals_php_version}"
+            $default_config_root  = "/etc/php/${globals_php_version}"
             $default_fpm_pid_file = "/var/run/php/php${globals_php_version}-fpm.pid"
-            $fpm_error_log       = "/var/log/php${globals_php_version}-fpm.log"
-            $fpm_service_name    = "php${globals_php_version}-fpm"
-            $ext_tool_enable     = "/usr/sbin/phpenmod -v ${globals_php_version}"
-            $ext_tool_query      = "/usr/sbin/phpquery -v ${globals_php_version}"
-            $package_prefix      = 'php5.6-'
+            $fpm_error_log        = "/var/log/php${globals_php_version}-fpm.log"
+            $fpm_service_name     = "php${globals_php_version}-fpm"
+            $ext_tool_enable      = "/usr/sbin/phpenmod -v ${globals_php_version}"
+            $ext_tool_query       = "/usr/sbin/phpquery -v ${globals_php_version}"
+            $package_prefix       = 'php5.6-'
           }
           /^7/: {
-            $default_config_root = "/etc/php/${globals_php_version}"
+            $default_config_root  = "/etc/php/${globals_php_version}"
             $default_fpm_pid_file = "/var/run/php/php${globals_php_version}-fpm.pid"
-            $fpm_error_log       = "/var/log/php${globals_php_version}-fpm.log"
-            $fpm_service_name    = "php${globals_php_version}-fpm"
-            $ext_tool_enable     = "/usr/sbin/phpenmod -v ${globals_php_version}"
-            $ext_tool_query      = "/usr/sbin/phpquery -v ${globals_php_version}"
-            $package_prefix      = 'php7.0-'
+            $fpm_error_log        = "/var/log/php${globals_php_version}-fpm.log"
+            $fpm_service_name     = "php${globals_php_version}-fpm"
+            $ext_tool_enable      = "/usr/sbin/phpenmod -v ${globals_php_version}"
+            $ext_tool_query       = "/usr/sbin/phpquery -v ${globals_php_version}"
+            $package_prefix       = 'php7.0-'
           }
           default: {
-            $default_config_root = "/etc/php/${globals_php_version}"
+            $default_config_root  = "/etc/php/${globals_php_version}"
             $default_fpm_pid_file = "/var/run/php/php${globals_php_version}-fpm.pid"
-            $fpm_error_log       = "/var/log/php${globals_php_version}-fpm.log"
-            $fpm_service_name    = "php${globals_php_version}-fpm"
-            $ext_tool_enable     = "/usr/sbin/phpenmod -v ${globals_php_version}"
-            $ext_tool_query      = "/usr/sbin/phpquery -v ${globals_php_version}"
-            $package_prefix      = 'php-'
+            $fpm_error_log        = "/var/log/php${globals_php_version}-fpm.log"
+            $fpm_service_name     = "php${globals_php_version}-fpm"
+            $ext_tool_enable      = "/usr/sbin/phpenmod -v ${globals_php_version}"
+            $ext_tool_query       = "/usr/sbin/phpquery -v ${globals_php_version}"
+            $package_prefix       = 'php-'
           }
         }
       } else {
         case $globals_php_version {
           /^7/: {
-            $default_config_root = "/etc/php/${globals_php_version}"
+            $default_config_root  = "/etc/php/${globals_php_version}"
             $default_fpm_pid_file = "/var/run/php/php${globals_php_version}-fpm.pid"
-            $fpm_error_log       = "/var/log/php${globals_php_version}-fpm.log"
-            $fpm_service_name    = "php${globals_php_version}-fpm"
-            $ext_tool_enable     = "/usr/sbin/phpenmod -v ${globals_php_version}"
-            $ext_tool_query      = "/usr/sbin/phpquery -v ${globals_php_version}"
-            $package_prefix      = 'php7.0-'
+            $fpm_error_log        = "/var/log/php${globals_php_version}-fpm.log"
+            $fpm_service_name     = "php${globals_php_version}-fpm"
+            $ext_tool_enable      = "/usr/sbin/phpenmod -v ${globals_php_version}"
+            $ext_tool_query       = "/usr/sbin/phpquery -v ${globals_php_version}"
+            $package_prefix       = 'php7.0-'
           }
           default: {
-            $default_config_root = '/etc/php5'
+            $default_config_root  = '/etc/php5'
             $default_fpm_pid_file = '/var/run/php5-fpm.pid'
-            $fpm_error_log       = '/var/log/php5-fpm.log'
-            $fpm_service_name    = 'php5-fpm'
-            $ext_tool_enable     = '/usr/sbin/php5enmod'
-            $ext_tool_query      = '/usr/sbin/php5query'
-            $package_prefix      = 'php5-'
+            $fpm_error_log        = '/var/log/php5-fpm.log'
+            $fpm_service_name     = 'php5-fpm'
+            $ext_tool_enable      = '/usr/sbin/php5enmod'
+            $ext_tool_query       = '/usr/sbin/php5query'
+            $package_prefix       = 'php5-'
           }
         }
       }

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -11,12 +11,16 @@
 class php::globals (
   $php_version = undef,
   $config_root = undef,
+  $fpm_pid_file = undef,
 ) {
   if $php_version != undef {
     validate_re($php_version, '^[57].[0-9]')
   }
   if $config_root != undef {
     validate_absolute_path($config_root)
+  }
+  if $fpm_pid_file != undef {
+    validate_absolute_path($fpm_pid_file)
   }
 
   $default_php_version = $::osfamily ? {
@@ -36,33 +40,36 @@ class php::globals (
     'Debian': {
       case $globals_php_version {
         /^7/: {
-          $default_config_root = "/etc/php/${globals_php_version}"
-          $fpm_pid_file        = "/var/run/php/php${globals_php_version}-fpm.pid"
-          $fpm_error_log       = "/var/log/php${globals_php_version}-fpm.log"
-          $fpm_service_name    = "php${globals_php_version}-fpm"
-          $ext_tool_enable     = "/usr/sbin/phpenmod -v ${globals_php_version}"
-          $ext_tool_query      = "/usr/sbin/phpquery -v ${globals_php_version}"
-          $package_prefix      = 'php-'
+          $default_config_root  = "/etc/php/${globals_php_version}"
+          $default_fpm_pid_file = "/var/run/php/php${globals_php_version}-fpm.pid"
+          $fpm_error_log        = "/var/log/php${globals_php_version}-fpm.log"
+          $fpm_service_name     = "php${globals_php_version}-fpm"
+          $ext_tool_enable      = "/usr/sbin/phpenmod -v ${globals_php_version}"
+          $ext_tool_query       = "/usr/sbin/phpquery -v ${globals_php_version}"
+          $package_prefix       = 'php-'
         }
         default: {
-          $default_config_root = '/etc/php5'
-          $fpm_pid_file        = '/var/run/php5-fpm.pid'
-          $fpm_error_log       = '/var/log/php5-fpm.log'
-          $fpm_service_name    = 'php5-fpm'
-          $ext_tool_enable     = '/usr/sbin/php5enmod'
-          $ext_tool_query      = '/usr/sbin/php5query'
-          $package_prefix      = 'php5-'
+          $default_config_root  = '/etc/php5'
+          $default_fpm_pid_file = '/var/run/php5-fpm.pid'
+          $fpm_error_log        = '/var/log/php5-fpm.log'
+          $fpm_service_name     = 'php5-fpm'
+          $ext_tool_enable      = '/usr/sbin/php5enmod'
+          $ext_tool_query       = '/usr/sbin/php5query'
+          $package_prefix       = 'php5-'
         }
       }
     }
     'Suse': {
-      $default_config_root = '/etc/php5'
+      $default_config_root  = '/etc/php5'
+      $default_fpm_pid_file = '/var/run/php5-fpm.pid'
     }
     'RedHat': {
-      $default_config_root = '/etc/php.d'
+      $default_config_root  = '/etc/php.d'
+      $default_fpm_pid_file = '/var/run/php-fpm/php-fpm.pid'
     }
     'FreeBSD': {
-      $default_config_root = '/usr/local/etc'
+      $default_config_root  = '/usr/local/etc'
+      $default_fpm_pid_file = '/var/run/php-fpm.pid'
     }
     default: {
       fail("Unsupported osfamily: ${::osfamily}")
@@ -70,4 +77,6 @@ class php::globals (
   }
 
   $globals_config_root = pick($config_root, $default_config_root)
+
+  $globals_fpm_pid_file = pick($fpm_pid_file, $default_fpm_pid_file)
 }

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -11,12 +11,17 @@
 class php::globals (
   $php_version = undef,
   $config_root = undef,
+  $fpm_pid_file = undef,
 ) {
   if $php_version != undef {
     validate_re($php_version, '^[57].[0-9]')
   }
   if $config_root != undef {
     validate_absolute_path($config_root)
+  }
+
+  if $fpm_pid_file != undef {
+    validate_absolute_path($fpm_pid_file)
   }
 
   $default_php_version = $::osfamily ? {
@@ -38,7 +43,7 @@ class php::globals (
         case $globals_php_version {
           /^5\.4/: {
             $default_config_root = '/etc/php5'
-            $fpm_pid_file        = '/var/run/php5-fpm.pid'
+            $default_fpm_pid_file = "/var/run/php/php${globals_php_version}-fpm.pid"
             $fpm_error_log       = '/var/log/php5-fpm.log'
             $fpm_service_name    = 'php5-fpm'
             $ext_tool_enable     = '/usr/sbin/php5enmod'
@@ -47,7 +52,7 @@ class php::globals (
           }
           /^5\.5/: {
             $default_config_root = "/etc/php/${globals_php_version}"
-            $fpm_pid_file        = "/var/run/php/php${globals_php_version}-fpm.pid"
+            $default_fpm_pid_file = "/var/run/php/php${globals_php_version}-fpm.pid"
             $fpm_error_log       = "/var/log/php${globals_php_version}-fpm.log"
             $fpm_service_name    = "php${globals_php_version}-fpm"
             $ext_tool_enable     = "/usr/sbin/phpenmod -v ${globals_php_version}"
@@ -56,7 +61,7 @@ class php::globals (
           }
           /^5\.6/: {
             $default_config_root = "/etc/php/${globals_php_version}"
-            $fpm_pid_file        = "/var/run/php/php${globals_php_version}-fpm.pid"
+            $default_fpm_pid_file = "/var/run/php/php${globals_php_version}-fpm.pid"
             $fpm_error_log       = "/var/log/php${globals_php_version}-fpm.log"
             $fpm_service_name    = "php${globals_php_version}-fpm"
             $ext_tool_enable     = "/usr/sbin/phpenmod -v ${globals_php_version}"
@@ -65,7 +70,7 @@ class php::globals (
           }
           /^7/: {
             $default_config_root = "/etc/php/${globals_php_version}"
-            $fpm_pid_file        = "/var/run/php/php${globals_php_version}-fpm.pid"
+            $default_fpm_pid_file = "/var/run/php/php${globals_php_version}-fpm.pid"
             $fpm_error_log       = "/var/log/php${globals_php_version}-fpm.log"
             $fpm_service_name    = "php${globals_php_version}-fpm"
             $ext_tool_enable     = "/usr/sbin/phpenmod -v ${globals_php_version}"
@@ -74,7 +79,7 @@ class php::globals (
           }
           default: {
             $default_config_root = "/etc/php/${globals_php_version}"
-            $fpm_pid_file        = "/var/run/php/php${globals_php_version}-fpm.pid"
+            $default_fpm_pid_file = "/var/run/php/php${globals_php_version}-fpm.pid"
             $fpm_error_log       = "/var/log/php${globals_php_version}-fpm.log"
             $fpm_service_name    = "php${globals_php_version}-fpm"
             $ext_tool_enable     = "/usr/sbin/phpenmod -v ${globals_php_version}"
@@ -86,7 +91,7 @@ class php::globals (
         case $globals_php_version {
           /^7/: {
             $default_config_root = "/etc/php/${globals_php_version}"
-            $fpm_pid_file        = "/var/run/php/php${globals_php_version}-fpm.pid"
+            $default_fpm_pid_file = "/var/run/php/php${globals_php_version}-fpm.pid"
             $fpm_error_log       = "/var/log/php${globals_php_version}-fpm.log"
             $fpm_service_name    = "php${globals_php_version}-fpm"
             $ext_tool_enable     = "/usr/sbin/phpenmod -v ${globals_php_version}"
@@ -95,7 +100,7 @@ class php::globals (
           }
           default: {
             $default_config_root = '/etc/php5'
-            $fpm_pid_file        = '/var/run/php5-fpm.pid'
+            $default_fpm_pid_file = '/var/run/php5-fpm.pid'
             $fpm_error_log       = '/var/log/php5-fpm.log'
             $fpm_service_name    = 'php5-fpm'
             $ext_tool_enable     = '/usr/sbin/php5enmod'
@@ -106,13 +111,16 @@ class php::globals (
       }
     }
     'Suse': {
-      $default_config_root = '/etc/php5'
+      $default_config_root  = '/etc/php5'
+      $default_fpm_pid_file = '/var/run/php5-fpm.pid'
     }
     'RedHat': {
-      $default_config_root = '/etc/php.d'
+      $default_config_root  = '/etc/php.d'
+      $default_fpm_pid_file = '/var/run/php-fpm/php-fpm.pid'
     }
     'FreeBSD': {
-      $default_config_root = '/usr/local/etc'
+      $default_config_root  = '/usr/local/etc'
+      $default_fpm_pid_file = '/var/run/php-fpm.pid'
     }
     default: {
       fail("Unsupported osfamily: ${::osfamily}")
@@ -120,4 +128,6 @@ class php::globals (
   }
 
   $globals_config_root = pick($config_root, $default_config_root)
+
+  $globals_fpm_pid_file = pick($fpm_pid_file, $default_fpm_pid_file)
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,7 +23,7 @@ class php::params inherits php::globals {
       $common_package_suffixes = ['cli', 'common']
       $cli_inifile             = "${config_root}/cli/php.ini"
       $dev_package_suffix      = 'dev'
-      $fpm_pid_file            = $php::globals::fpm_pid_file
+      $fpm_pid_file            = $php::globals::globals_fpm_pid_file
       $fpm_config_file         = "${config_root}/fpm/php-fpm.conf"
       $fpm_error_log           = $php::globals::fpm_error_log
       $fpm_inifile             = "${config_root}/fpm/php.ini"
@@ -64,7 +64,7 @@ class php::params inherits php::globals {
       $common_package_suffixes = []
       $cli_inifile             = "${config_root}/cli/php.ini"
       $dev_package_suffix      = 'devel'
-      $fpm_pid_file            = '/var/run/php5-fpm.pid'
+      $fpm_pid_file            = $php::globals::globals_fpm_pid_file
       $fpm_config_file         = "${config_root}/fpm/php-fpm.conf"
       $fpm_error_log           = '/var/log/php5-fpm.log'
       $fpm_inifile             = "${config_root}/fpm/php.ini"
@@ -98,7 +98,7 @@ class php::params inherits php::globals {
       $common_package_suffixes = ['cli', 'common']
       $cli_inifile             = '/etc/php-cli.ini'
       $dev_package_suffix      = 'devel'
-      $fpm_pid_file            = '/var/run/php-fpm/php-fpm.pid'
+      $fpm_pid_file            = $php::globals::globals_fpm_pid_file
       $fpm_config_file         = '/etc/php-fpm.conf'
       $fpm_error_log           = '/var/log/php-fpm/error.log'
       $fpm_inifile             = '/etc/php-fpm.ini'
@@ -126,7 +126,7 @@ class php::params inherits php::globals {
       $common_package_suffixes = ['extensions']
       $cli_inifile             = "${config_root}/php-cli.ini"
       $dev_package_suffix      = undef
-      $fpm_pid_file            = '/var/run/php-fpm.pid'
+      $fpm_pid_file            = $php::globals::globals_fpm_pid_file
       $fpm_config_file         = "${config_root}/php-fpm.conf"
       $fpm_error_log           = '/var/log/php-fpm.log'
       $fpm_inifile             = "${config_root}/php-fpm.ini"

--- a/templates/fpm/php-fpm.conf.erb
+++ b/templates/fpm/php-fpm.conf.erb
@@ -3,14 +3,14 @@
 ;;;;;;;;;;;;;;;;;;;;;
 
 ; All relative paths in this configuration file are relative to PHP's install
-; prefix (/usr). This prefix can be dynamicaly changed by using the
+; prefix (/usr). This prefix can be dynamically changed by using the
 ; '-p' argument from the command line.
 
 ; Include one or more files. If glob(3) exists, it is used to include a bunch of
 ; files from a glob(3) pattern. This directive can be used everywhere in the
 ; file.
 ; Relative path can also be used. They will be prefixed by:
-;  - the global prefix if it's been set (-p arguement)
+;  - the global prefix if it's been set (-p argument)
 ;  - /usr otherwise
 ;include=/etc/php5/fpm/*.conf
 
@@ -109,7 +109,7 @@ rlimit_files = <%= @rlimit_files %>
 ; - /dev/poll  (Solaris >= 7)
 ; - port       (Solaris >= 10)
 ; Default Value: not set (auto detection)
-; events.mechanism = epoll
+;events.mechanism = epoll
 
 ; When FPM is build with systemd integration, specify the interval,
 ; in second, between health report notification to systemd.


### PR DESCRIPTION
allow of passing a pid file to globals like so:
```puppet
class { '::php::globals':
                php_version => '5.5',
                fpm_pid_file => '/var/run/php-fpm/php-fpm-5.5.pid',
        } ->
        class { '::php':
                ensure       => latest,
                manage_repos => false,
                fpm          => false,
                dev          => false,
                composer     => false,
                pear         => true,
                phpunit      => false,
        }
```
This was need to address amazon linux and a init.d pid file looking for:
`pidfile=${PIDFILE-/var/run/php-fpm/php-fpm-5.5.pid}`

