### PR TITLE
Ondrej-php PPA fixes/enhancements for Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,9 +189,27 @@ upstream.
 
 To use an alternate PPA, Ondrej's PHP 5.6 for example, use the below hiera snippet
 ```yaml
-php::repo::ubuntu::ppa: 'ondrej/php5-5.6'
+php::repo::ubuntu::ppa: 'ondrej/php'
 php::manage_repos: true
 ```
+
+### Ubuntu systems and Ondrej's PPA
+
+The older Ubuntu PPAs run by Ondrej have been deprecated (ondrej/php5, ondrej/php5.6)
+in favor of a new PPA: ondrej/php which contains all 3 versions of PHP: 5.5, 5.6, and 7.0
+Here's an example in hiera of getting PHP 5.6 installed with php-fpm, pear/pecl, and composer:
+
+```
+php::globals::php_version: '5.6'
+php::fpm: true
+php::dev: true
+php::composer: true
+php::pear: true
+php::phpunit: false
+```
+
+If you do not specify a php version, in Ubuntu the default will be 7.0 if you are
+running Xenial (16.04), otherwise PHP 5.6 will be installed (for other versions)
 
 ### Apache support
 

--- a/README.md
+++ b/README.md
@@ -187,15 +187,15 @@ older though still supported distribution release. Our default is to have
 Ubuntu with packages for the current stable PHP version closely tracking
 upstream.
 
-To use an alternate PPA, Ondrej's PHP 5.6 for example, use the below hiera snippet
+To use an alternate PPA, Ondřej's PHP 5.6 for example, use the below hiera snippet
 ```yaml
 php::repo::ubuntu::ppa: 'ondrej/php'
 php::manage_repos: true
 ```
 
-### Ubuntu systems and Ondrej's PPA
+### Ubuntu systems and Ondřej's PPA
 
-The older Ubuntu PPAs run by Ondrej have been deprecated (ondrej/php5, ondrej/php5.6)
+The older Ubuntu PPAs run by Ondřej have been deprecated (ondrej/php5, ondrej/php5.6)
 in favor of a new PPA: ondrej/php which contains all 3 versions of PHP: 5.5, 5.6, and 7.0
 Here's an example in hiera of getting PHP 5.6 installed with php-fpm, pear/pecl, and composer:
 

--- a/manifests/dev.pp
+++ b/manifests/dev.pp
@@ -26,8 +26,17 @@ class php::dev(
     default   => $package,
   }
 
-  package { $real_package:
-    ensure  => $ensure,
-    require => Class['::php::packages'],
+  if $::operatingsystem == 'Ubuntu' {
+    ensure_packages(["${php::globals::package_prefix}xml"])
+
+    package { $real_package:
+      ensure  => $ensure,
+      require => Class['::php::packages'],
+    }
+  } else {
+    package { $real_package:
+      ensure  => $ensure,
+      require => Class['::php::packages'],
+    }
   }
 }

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -23,7 +23,7 @@ class php::globals (
     'Debian' => $::operatingsystem ? {
       'Ubuntu' => $::operatingsystemrelease ? {
         /^(16.04)$/ => '7.0',
-        default => '5.x',
+        default => '5.6',
       },
       default => '5.x',
     },
@@ -34,24 +34,74 @@ class php::globals (
 
   case $::osfamily {
     'Debian': {
-      case $globals_php_version {
-        /^7/: {
-          $default_config_root = "/etc/php/${globals_php_version}"
-          $fpm_pid_file        = "/var/run/php/php${globals_php_version}-fpm.pid"
-          $fpm_error_log       = "/var/log/php${globals_php_version}-fpm.log"
-          $fpm_service_name    = "php${globals_php_version}-fpm"
-          $ext_tool_enable     = "/usr/sbin/phpenmod -v ${globals_php_version}"
-          $ext_tool_query      = "/usr/sbin/phpquery -v ${globals_php_version}"
-          $package_prefix      = 'php-'
+      if $::operatingsystem == 'Ubuntu' {
+        case $globals_php_version {
+          /^5\.4/: {
+            $default_config_root = '/etc/php5'
+            $fpm_pid_file        = '/var/run/php5-fpm.pid'
+            $fpm_error_log       = '/var/log/php5-fpm.log'
+            $fpm_service_name    = 'php5-fpm'
+            $ext_tool_enable     = '/usr/sbin/php5enmod'
+            $ext_tool_query      = '/usr/sbin/php5query'
+            $package_prefix      = 'php5-'
+          }
+          /^5\.5/: {
+            $default_config_root = "/etc/php/${globals_php_version}"
+            $fpm_pid_file        = "/var/run/php/php${globals_php_version}-fpm.pid"
+            $fpm_error_log       = "/var/log/php${globals_php_version}-fpm.log"
+            $fpm_service_name    = "php${globals_php_version}-fpm"
+            $ext_tool_enable     = "/usr/sbin/phpenmod -v ${globals_php_version}"
+            $ext_tool_query      = "/usr/sbin/phpquery -v ${globals_php_version}"
+            $package_prefix      = 'php5.5-'
+          }
+          /^5\.6/: {
+            $default_config_root = "/etc/php/${globals_php_version}"
+            $fpm_pid_file        = "/var/run/php/php${globals_php_version}-fpm.pid"
+            $fpm_error_log       = "/var/log/php${globals_php_version}-fpm.log"
+            $fpm_service_name    = "php${globals_php_version}-fpm"
+            $ext_tool_enable     = "/usr/sbin/phpenmod -v ${globals_php_version}"
+            $ext_tool_query      = "/usr/sbin/phpquery -v ${globals_php_version}"
+            $package_prefix      = 'php5.6-'
+          }
+          /^7/: {
+            $default_config_root = "/etc/php/${globals_php_version}"
+            $fpm_pid_file        = "/var/run/php/php${globals_php_version}-fpm.pid"
+            $fpm_error_log       = "/var/log/php${globals_php_version}-fpm.log"
+            $fpm_service_name    = "php${globals_php_version}-fpm"
+            $ext_tool_enable     = "/usr/sbin/phpenmod -v ${globals_php_version}"
+            $ext_tool_query      = "/usr/sbin/phpquery -v ${globals_php_version}"
+            $package_prefix      = 'php7.0-'
+          }
+          default: {
+            $default_config_root = "/etc/php/${globals_php_version}"
+            $fpm_pid_file        = "/var/run/php/php${globals_php_version}-fpm.pid"
+            $fpm_error_log       = "/var/log/php${globals_php_version}-fpm.log"
+            $fpm_service_name    = "php${globals_php_version}-fpm"
+            $ext_tool_enable     = "/usr/sbin/phpenmod -v ${globals_php_version}"
+            $ext_tool_query      = "/usr/sbin/phpquery -v ${globals_php_version}"
+            $package_prefix      = 'php-'
+          }
         }
-        default: {
-          $default_config_root = '/etc/php5'
-          $fpm_pid_file        = '/var/run/php5-fpm.pid'
-          $fpm_error_log       = '/var/log/php5-fpm.log'
-          $fpm_service_name    = 'php5-fpm'
-          $ext_tool_enable     = '/usr/sbin/php5enmod'
-          $ext_tool_query      = '/usr/sbin/php5query'
-          $package_prefix      = 'php5-'
+      } else {
+        case $globals_php_version {
+          /^7/: {
+            $default_config_root = "/etc/php/${globals_php_version}"
+            $fpm_pid_file        = "/var/run/php/php${globals_php_version}-fpm.pid"
+            $fpm_error_log       = "/var/log/php${globals_php_version}-fpm.log"
+            $fpm_service_name    = "php${globals_php_version}-fpm"
+            $ext_tool_enable     = "/usr/sbin/phpenmod -v ${globals_php_version}"
+            $ext_tool_query      = "/usr/sbin/phpquery -v ${globals_php_version}"
+            $package_prefix      = 'php-'
+          }
+          default: {
+            $default_config_root = '/etc/php5'
+            $fpm_pid_file        = '/var/run/php5-fpm.pid'
+            $fpm_error_log       = '/var/log/php5-fpm.log'
+            $fpm_service_name    = 'php5-fpm'
+            $ext_tool_enable     = '/usr/sbin/php5enmod'
+            $ext_tool_query      = '/usr/sbin/php5query'
+            $package_prefix      = 'php5-'
+          }
         }
       }
     }

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -29,7 +29,14 @@ class php::packages (
   validate_array($names_to_prefix)
 
   $real_names = union($names, $names_to_prefix)
-  package { $real_names:
-    ensure => $ensure,
+  if $::operatingsystem == 'Ubuntu' {
+    package { $real_names:
+      ensure  => $ensure,
+      require => Class['::php::repo'],
+    }
+  } else {
+    package { $real_names:
+      ensure => $ensure,
+    }
   }
 }

--- a/manifests/pear.pp
+++ b/manifests/pear.pp
@@ -43,9 +43,18 @@ class php::pear (
   validate_string($ensure)
   validate_string($package_name)
 
-  package { $package_name:
-    ensure  => $ensure,
-    require => Class['::php::cli'],
-  }
+  if $::operatingsystem == 'Ubuntu' {
 
+    ensure_packages(["${php::globals::package_prefix}xml"])
+
+    package { $package_name:
+      ensure  => $ensure,
+      require => [Class['::php::repo'],Class['::php::cli'],Package["${php::globals::package_prefix}xml"]],
+    }
+  } else {
+    package { $package_name:
+      ensure  => $ensure,
+      require => Class['::php::cli'],
+    }
+  }
 }

--- a/manifests/repo/ubuntu.pp
+++ b/manifests/repo/ubuntu.pp
@@ -6,7 +6,7 @@
 #   PHP version to manage (e.g. 5.6)
 #
 # [*ppa*]
-#   Use a specific PPA, e.g "ondrej/php5-5.6" (without the "ppa:")
+#   Use a specific PPA, e.g "ondrej/php" (without the "ppa:")
 #
 class php::repo::ubuntu (
   $version   = undef,

--- a/manifests/repo/ubuntu.pp
+++ b/manifests/repo/ubuntu.pp
@@ -24,8 +24,8 @@ class php::repo::ubuntu (
 
   $version_repo = $version_real ? {
     '5.4' => 'ondrej/php5-oldstable',
-    '5.5' => 'ondrej/php5',
-    '5.6' => 'ondrej/php5-5.6',
+    '5.5' => 'ondrej/php',
+    '5.6' => 'ondrej/php',
     '7.0' => 'ondrej/php'
   }
 
@@ -34,8 +34,12 @@ class php::repo::ubuntu (
   }
 
   if ($ppa) {
-    ::apt::ppa { "ppa:${ppa}": }
+    ::apt::ppa { "ppa:${ppa}":
+      before => [Class['::php::packages'],Class['::php::pear'],Class['::php::dev']],
+    }
   } else {
-    ::apt::ppa { "ppa:${version_repo}": }
+    ::apt::ppa { "ppa:${version_repo}":
+      before => [Class['::php::packages'],Class['::php::pear'],Class['::php::dev']],
+    }
   }
 }

--- a/spec/classes/php_fpm_config_spec.rb
+++ b/spec/classes/php_fpm_config_spec.rb
@@ -7,28 +7,54 @@ describe 'php::fpm::config' do
         facts
       end
 
-      describe 'creates config file' do
-        let(:params) {{
-          :inifile  => '/etc/php5/conf.d/unique-name.ini',
-          :settings => {
-            'apc.enabled' => 1,
-           },
-        }}
+      case facts[:operatingsystem]
+      when 'Ubuntu'
+        describe 'creates config file' do
+          let(:params) {{
+            :inifile  => '/etc/php/5.6/conf.d/unique-name.ini',
+            :settings => {
+              'apc.enabled' => 1,
+             },
+          }}
 
-         it { should contain_class('php::fpm::config').with({
-           :inifile  => '/etc/php5/conf.d/unique-name.ini',
-           :settings => {
-             'apc.enabled' => 1,
-           },
-         })}
+           it { should contain_class('php::fpm::config').with({
+             :inifile  => '/etc/php/5.6/conf.d/unique-name.ini',
+             :settings => {
+               'apc.enabled' => 1,
+             },
+           })}
 
-         it { should contain_php__config('fpm').with({
-          :file   => '/etc/php5/conf.d/unique-name.ini',
-          :config => {
-            'apc.enabled' => 1,
-          },
-        })}
-      end
+           it { should contain_php__config('fpm').with({
+            :file   => '/etc/php/5.6/conf.d/unique-name.ini',
+            :config => {
+              'apc.enabled' => 1,
+            },
+           })}
+         end
+       else
+         describe 'creates config file' do
+           let(:params) {{
+             :inifile  => '/etc/php5/conf.d/unique-name.ini',
+             :settings => {
+               'apc.enabled' => 1,
+              },
+           }}
+   
+            it { should contain_class('php::fpm::config').with({
+              :inifile  => '/etc/php5/conf.d/unique-name.ini',
+              :settings => {
+                'apc.enabled' => 1,
+              },
+            })}
+
+            it { should contain_php__config('fpm').with({
+             :file   => '/etc/php5/conf.d/unique-name.ini',
+             :config => {
+               'apc.enabled' => 1,
+             },
+           })}
+         end
+       end
     end
   end
 end

--- a/spec/classes/php_fpm_spec.rb
+++ b/spec/classes/php_fpm_spec.rb
@@ -10,15 +10,28 @@ describe 'php::fpm', :type => :class do
       describe 'when called with no parameters' do
         case facts[:osfamily]
         when 'Debian'
-          let(:params) { { :package => 'php5-fpm', :ensure => 'latest' } }
-          it {
-            should contain_package('php5-fpm').with({
-              'ensure' => 'latest',
-            })
-            should contain_service('php5-fpm').with({
-              'ensure' => 'running',
-            })
-          }
+          case facts[:operatingsystem]
+          when 'Ubuntu'
+            let(:params) { { :package => 'php5.6-fpm', :ensure => 'latest' } }
+            it {
+              should contain_package('php5.6-fpm').with({
+                'ensure' => 'latest',
+              })
+              should contain_service('php5.6-fpm').with({
+                'ensure' => 'running',
+              })
+            }
+          when 'Debian'
+            let(:params) { { :package => 'php5-fpm', :ensure => 'latest' } }
+            it {
+              should contain_package('php5-fpm').with({
+                'ensure' => 'latest',
+              })
+              should contain_service('php5-fpm').with({
+                'ensure' => 'running',
+              })
+            }
+          end
         else
           it {
             should contain_service('php-fpm').with({

--- a/spec/classes/php_repo_ubuntu_spec.rb
+++ b/spec/classes/php_repo_ubuntu_spec.rb
@@ -11,7 +11,7 @@ describe 'php::repo::ubuntu', :type => :class do
       when 'trusty'
         describe 'when called with no parameters on Ubuntu trusty' do
           it {
-            should contain_exec('add-apt-repository-ppa:ondrej/php5')
+            should contain_exec('add-apt-repository-ppa:ondrej/php')
           }
         end
 
@@ -26,17 +26,17 @@ describe 'php::repo::ubuntu', :type => :class do
 
         describe 'when call with parameter ppa without prefix "ppa:" on Ubuntu trusty' do
           let(:params) {{
-              :ppa => 'ondrej/php5-5.6'
+              :ppa => 'ondrej/php'
           }}
           it {
-            should contain_exec('add-apt-repository-ppa:ondrej/php5-5.6')
+            should contain_exec('add-apt-repository-ppa:ondrej/php')
           }
         end
 
         describe 'when call with parameter ppa and version on Ubuntu trusty' do
           let(:params) {{
               :version => '5.4',
-              :ppa     => 'ondrej/php5-5.6'
+              :ppa     => 'ondrej/php5-oldstable'
           }}
           it { expect { should raise_error(Puppet::Error) }}
         end

--- a/spec/classes/php_spec.rb
+++ b/spec/classes/php_spec.rb
@@ -10,22 +10,42 @@ describe 'php', :type => :class do
       describe 'when called with no parameters' do
         case facts[:osfamily]
         when 'Debian'
-          it {
-            should contain_class('php::fpm')
-            should contain_package('php5-cli').with({
-              'ensure' => 'present',
-            })
-            should contain_package('php5-fpm').with({
-              'ensure' => 'present',
-            })
-            should contain_package('php5-dev').with({
-              'ensure' => 'present',
-            })
-            should contain_package('php-pear').with({
-              'ensure' => 'present',
-            })
-            should contain_class('php::composer')
-          }
+          case facts[:operatingsystem]
+          when 'Ubuntu'
+            it {
+              should contain_class('php::fpm')
+              should contain_package('php5.6-cli').with({
+                'ensure' => 'present',
+              })
+              should contain_package('php5.6-fpm').with({
+                'ensure' => 'present',
+              })
+              should contain_package('php5.6-dev').with({
+                'ensure' => 'present',
+              })
+              should contain_package('php-pear').with({
+                'ensure' => 'present',
+              })
+              should contain_class('php::composer')
+            }
+          when 'Debian'
+            it {
+              should contain_class('php::fpm')
+              should contain_package('php5-cli').with({
+                'ensure' => 'present',
+              })
+              should contain_package('php5-fpm').with({
+                'ensure' => 'present',
+              })
+              should contain_package('php5-dev').with({
+                'ensure' => 'present',
+              })
+              should contain_package('php-pear').with({
+                'ensure' => 'present',
+              })
+              should contain_class('php::composer')
+            }
+          end
         when 'Suse'
           it {
             should contain_package('php5').with({

--- a/spec/defines/config_spec.rb
+++ b/spec/defines/config_spec.rb
@@ -6,44 +6,88 @@ describe 'php::config' do
       let :facts do
         facts
       end
-      context 'default config' do
-        let(:title) { 'unique-name' }
-        let(:params) {{
-          :file   => '/etc/php5/conf.d/unique-name.ini',
-          :config => {}
-        }}
-      end
 
-      context 'simple example' do
-        let(:title) { 'unique-name' }
-        let(:params) {{
-          :file   => '/etc/php5/conf.d/unique-name.ini',
-          :config => {
-            'apc.enabled' => 1
-          }
-        }}
+      case facts[:operatingsystem]
+      when 'Ubuntu'
+        context 'default config' do
+          let(:title) { 'unique-name' }
+          let(:params) {{
+            :file   => '/etc/php/5.6/conf.d/unique-name.ini',
+            :config => {}
+          }}
+        end
 
-        it { should contain_php__config('unique-name').with({'file' => '/etc/php5/conf.d/unique-name.ini'})}
-      end
+        context 'simple example' do
+          let(:title) { 'unique-name' }
+          let(:params) {{
+            :file   => '/etc/php/5.6/conf.d/unique-name.ini',
+            :config => {
+              'apc.enabled' => 1
+            }
+          }}
 
-      context 'empty array' do
-        let(:title) { 'unique-name' }
-        let(:params) {{
-          :file   => '/etc/php5/conf.d/unique-name.ini',
-          :config => {}
-        }}
+          it { should contain_php__config('unique-name').with({'file' => '/etc/php/5.6/conf.d/unique-name.ini'})}
+        end
 
-        it { should contain_php__config('unique-name').with({'file' => '/etc/php5/conf.d/unique-name.ini'})}
-      end
+        context 'empty array' do
+          let(:title) { 'unique-name' }
+          let(:params) {{
+            :file   => '/etc/php/5.6/conf.d/unique-name.ini',
+            :config => {}
+          }}
 
-      context 'invalid config (string)' do
-        let(:title) { 'unique-name' }
-        let(:params) {{
-          :file   => '/etc/php5/conf.d/unique-name.ini',
-          :config => 'hello world'
-        }}
+          it { should contain_php__config('unique-name').with({'file' => '/etc/php/5.6/conf.d/unique-name.ini'})}
+        end
 
-        it { expect { should raise_error(Puppet::Error) }}
+        context 'invalid config (string)' do
+          let(:title) { 'unique-name' }
+          let(:params) {{
+            :file   => '/etc/php/5.6/conf.d/unique-name.ini',
+            :config => 'hello world'
+          }}
+
+          it { expect { should raise_error(Puppet::Error) }}
+        end
+      else
+        context 'default config' do
+          let(:title) { 'unique-name' }
+          let(:params) {{
+            :file   => '/etc/php5/conf.d/unique-name.ini',
+            :config => {}
+          }}
+        end
+
+        context 'simple example' do
+          let(:title) { 'unique-name' }
+          let(:params) {{
+            :file   => '/etc/php5/conf.d/unique-name.ini',
+            :config => {
+              'apc.enabled' => 1
+            }
+          }}
+
+          it { should contain_php__config('unique-name').with({'file' => '/etc/php5/conf.d/unique-name.ini'})}
+        end
+
+        context 'empty array' do
+          let(:title) { 'unique-name' }
+          let(:params) {{
+            :file   => '/etc/php5/conf.d/unique-name.ini',
+            :config => {}
+          }}
+
+          it { should contain_php__config('unique-name').with({'file' => '/etc/php5/conf.d/unique-name.ini'})}
+        end
+
+        context 'invalid config (string)' do
+          let(:title) { 'unique-name' }
+          let(:params) {{
+            :file   => '/etc/php5/conf.d/unique-name.ini',
+            :config => 'hello world'
+          }}
+
+          it { expect { should raise_error(Puppet::Error) }}
+        end
       end
     end
   end

--- a/spec/defines/extension_spec.rb
+++ b/spec/defines/extension_spec.rb
@@ -11,7 +11,12 @@ describe 'php::extension' do
       unless (facts[:osfamily] == 'Suse' || facts[:osfamily] == 'FreeBSD') # FIXME - something is wrong on these
         case facts[:osfamily]
           when 'Debian'
-            etcdir = '/etc/php5/mods-available'
+            case facts[:operatingsystem]
+              when 'Ubuntu'
+                etcdir = '/etc/php/5.6/mods-available'
+              else
+                etcdir = '/etc/php5/mods-available'
+            end
           else
             etcdir = '/etc/php.d'
         end

--- a/spec/defines/fpm_pool_spec.rb
+++ b/spec/defines/fpm_pool_spec.rb
@@ -8,11 +8,21 @@ describe 'php::fpm::pool' do
       end
       case facts[:osfamily]
         when 'Debian'
-        context 'plain config' do
-          let(:title) { 'unique-name' }
-          let(:params) {{ }}
+        case facts[:operatingsystem]
+        when 'Ubuntu'
+          context 'plain config' do
+            let(:title) { 'unique-name' }
+            let(:params) {{ }}
 
-          it { should contain_file('/etc/php5/fpm/pool.d/unique-name.conf') }
+            it { should contain_file('/etc/php/5.6/fpm/pool.d/unique-name.conf') }
+           end
+        when 'Debian'
+          context 'plain config' do
+            let(:title) { 'unique-name' }
+            let(:params) {{ }}
+
+            it { should contain_file('/etc/php5/fpm/pool.d/unique-name.conf') }
+          end
         end
       end
     end


### PR DESCRIPTION
Hi,

  I've been doing work to get mayflower-php working with the ondrej-php PPA. It appears ondrej/php5 and ondrej/php5.6 are now deprecated and he has combined PHP 5.5, 5.6 and 7.0 into one repo. This completely breaks the module as it currently is. I've also put in some fixes so that it actually adds the PPA before it even tries to install the packages (in packages.pp, pear.pp and dev.pp).

  Please test and let me know if all works as it should. I've tested it on Ubuntu 14.04 (Trusty) with versions 5.5, 5.6, and 7.0 with the PPA.