### PR TITLE
Don't manage global php.ini settings on Debian based systems

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -142,11 +142,13 @@ class php (
   anchor { 'php::end': }
 
   # Configure global PHP settings in php.ini
-  Anchor['php::begin'] ->
-  class {'::php::global':
-    settings => $real_settings,
-  } ->
-  Anchor['php::end']
+  if $::osfamily != 'Debian' {
+    Anchor['php::begin'] ->
+    class {'::php::global':
+      settings => $real_settings,
+    } ->
+    Anchor['php::end']
+  }
 
   if $fpm {
     Anchor['php::begin'] ->

--- a/spec/classes/php_spec.rb
+++ b/spec/classes/php_spec.rb
@@ -11,6 +11,7 @@ describe 'php', :type => :class do
         case facts[:osfamily]
         when 'Debian'
           it {
+            should_not contain_class('php::global')
             should contain_class('php::fpm')
             should contain_package('php5-cli').with({
               'ensure' => 'present',
@@ -28,6 +29,7 @@ describe 'php', :type => :class do
           }
         when 'Suse'
           it {
+            should contain_class('php::global')
             should contain_package('php5').with({
               'ensure' => 'present',
             })


### PR DESCRIPTION
#132 resulted in a global php.ini being created/managed to fix some issues on RedHat based systems.

Debian (and derivatives) don't actually have an `/etc/php|php5/php.ini`. All configuration lives under a SAPI. Configuring these settings in this global file does nothing under this family of operating systems.

I came across this when I noticed an ordering issue - settings in this file were trying to be managed _before_ the PHP packages were being installed, and as such `/etc/php5` didn't exist (see #191)

This PR stops managing the file, but doesn't clean it up on systems that might already have it. I didn't feel that was safe.