### PR TITLE
Avoid puppets warning in puppetserver.log

### DIFF
--- a/manifests/extension.pp
+++ b/manifests/extension.pp
@@ -94,7 +94,7 @@ define php::extension(
     else {
       $real_package = "${package_prefix}${title}"
     }
-   
+
     unless empty($header_packages) {
       ensure_resource('package', $header_packages)
       Package[$header_packages] -> Package[$real_package]

--- a/manifests/extension.pp
+++ b/manifests/extension.pp
@@ -94,10 +94,12 @@ define php::extension(
     else {
       $real_package = "${package_prefix}${title}"
     }
-
-    ensure_resource('package', $header_packages)
-    Package[$header_packages] -> Package[$real_package] -> ::Php::Config[$title]
-
+   
+    unless empty($header_packages) {
+      ensure_resource('package', $header_packages)
+      Package[$header_packages] -> Package[$real_package]
+    }
+    
     if $provider == 'pecl' {
       package { $real_package:
         ensure   => $ensure,
@@ -109,8 +111,10 @@ define php::extension(
         ],
       }
 
-      ensure_resource('package', $compiler_packages)
-      Package[$compiler_packages] -> Package[$real_package]
+      unless empty($compiler_packages) {
+        ensure_resource('package', $compiler_packages)
+        Package[$compiler_packages] -> Package[$real_package]
+      }
     }
     else {
       package { $real_package:
@@ -180,8 +184,9 @@ define php::extension(
 
   $config_root_ini = pick_default($::php::config_root_ini, $::php::params::config_root_ini)
   ::php::config { $title:
-    file   => "${config_root_ini}/${lowercase_title}.ini",
-    config => $final_settings,
+    file    => "${config_root_ini}/${lowercase_title}.ini",
+    config  => $final_settings,
+    require => Package[$real_package],
   }
 
   # Ubuntu/Debian systems use the mods-available folder. We need to enable


### PR DESCRIPTION
Hi,

puppet throws some warnings in the puppetserver.log (using 4.5.1), if puppet managed php an this host.

```
WARN  [qtp1416189715-65] [puppetserver] Puppet Arguments to Resource[] are all empty/undefined at /etc/puppetlabs/code/environments/productions/modules/php/manifests/extension.pp:99:13
```

I added a empty condition to define dependencies, if the header or compiler packages are required.