### PR TITLE
stop using LSB facts

### DIFF
--- a/manifests/fpm.pp
+++ b/manifests/fpm.pp
@@ -95,8 +95,7 @@ class php::fpm (
 
   # Create an override to use a reload signal as trusty and utopic's
   # upstart version supports this
-  if $::osfamily == 'Debian' and
-    ($::lsbdistcodename == 'trusty' or $::lsbdistcodename == 'utopic') {
+  if $::operatingsystem == 'Ubuntu' and ($::operatingsystemmajrelease == '14.04' or $::operatingsystemmajrelease == '14.10') {
     if ($service_enable) {
       $fpm_override = 'reload signal USR2'
     }

--- a/manifests/fpm/service.pp
+++ b/manifests/fpm/service.pp
@@ -23,13 +23,10 @@ class php::fpm::service(
 
   $reload = "service ${service_name} reload"
 
-  if $::osfamily == 'Debian' {
+  if $::operatingsystem == 'Ubuntu' and $::operatingsystemmajrelease == '12.04' {
     # Precise upstart doesn't support reload signals, so use
     # regular service restart instead
-    $restart = $::lsbdistcodename ? {
-      'precise' => undef,
-      default   => $reload
-    }
+    $restart = undef
   } else {
     $restart = $reload
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -43,7 +43,7 @@ class php::params inherits php::globals {
 
       case $::operatingsystem {
         'Debian': {
-          $manage_repos = $::lsbdistcodename == 'wheezy'
+          $manage_repos = (versioncmp($::operatingsystemrelease, '8') < 0)
         }
 
         'Ubuntu': {


### PR DESCRIPTION
closes GH-184

The lsb usage in the tests can stay as-is, as we do get lsb facts always in the facterdb provided facts.