### PR TITLE
Fixup naming of xml package for Ubuntu, when the package_prefix is

### DIFF
--- a/manifests/dev.pp
+++ b/manifests/dev.pp
@@ -27,7 +27,7 @@ class php::dev(
   }
 
   if $::operatingsystem == 'Ubuntu' {
-    ensure_packages(["${php::globals::package_prefix}xml"], {
+    ensure_packages(["${php::package_prefix}xml"], {
       ensure  => present,
       require => Class['::apt::update'],
     })

--- a/manifests/pear.pp
+++ b/manifests/pear.pp
@@ -44,14 +44,14 @@ class php::pear (
   validate_string($package_name)
 
   if $::operatingsystem == 'Ubuntu' {
-    ensure_packages(["${php::globals::package_prefix}xml"], {
+    ensure_packages(["${php::package_prefix}xml"], {
       ensure  => present,
       require => Class['::apt::update'],
     })
 
     package { $package_name:
       ensure  => $ensure,
-      require => [Class['::apt::update'],Class['::php::cli'],Package["${php::globals::package_prefix}xml"]],
+      require => [Class['::apt::update'],Class['::php::cli'],Package["${php::package_prefix}xml"]],
     }
   } else {
     package { $package_name:

--- a/spec/classes/php_spec.rb
+++ b/spec/classes/php_spec.rb
@@ -20,7 +20,12 @@ describe 'php', :type => :class do
               should contain_package('php5.6-fpm').with({
                 'ensure' => 'present',
               })
+              should contain_class('php::dev')
               should contain_package('php5.6-dev').with({
+                'ensure' => 'present',
+              })
+              # The -xml package is enforced via the dev class
+              should contain_package('php5.6-xml').with({
                 'ensure' => 'present',
               })
               should contain_package('php-pear').with({
@@ -61,6 +66,71 @@ describe 'php', :type => :class do
             })
             should_not contain_package('php5-cli')
             should_not contain_package('php5-dev')
+            should_not contain_package('php-pear')
+          }
+        end
+      end
+
+      describe 'when called with package_prefix parameter' do
+        let(:params) { { :package_prefix => 'myphp-', } }
+        case facts[:osfamily]
+        when 'Debian'
+          case facts[:operatingsystem]
+          when 'Ubuntu'
+            it {
+              should contain_class('php::fpm')
+              should contain_package('myphp-cli').with({
+                'ensure' => 'present',
+              })
+              should contain_package('myphp-fpm').with({
+                'ensure' => 'present',
+              })
+              should contain_class('php::dev')
+              should contain_package('myphp-dev').with({
+                'ensure' => 'present',
+              })
+              # The -xml package is enforced via the dev class
+              should contain_package('myphp-xml').with({
+                'ensure' => 'present',
+              })
+              should contain_package('php-pear').with({
+                'ensure' => 'present',
+              })
+              should contain_class('php::composer')
+            }
+          when 'Debian'
+            it {
+              should_not contain_class('php::global')
+              should contain_class('php::fpm')
+              should contain_package('myphp-cli').with({
+                'ensure' => 'present',
+              })
+              should contain_package('myphp-fpm').with({
+                'ensure' => 'present',
+              })
+              should contain_package('myphp-dev').with({
+                'ensure' => 'present',
+              })
+              should contain_package('php-pear').with({
+                'ensure' => 'present',
+              })
+              should contain_class('php::composer')
+            }
+          end
+        when 'Suse'
+          it {
+            should contain_class('php::global')
+            should contain_package('php5').with({
+              'ensure' => 'present',
+            })
+            should contain_package('myphp-devel').with({
+              'ensure' => 'present',
+            })
+            should contain_package('myphp-pear').with({
+              'ensure' => 'present',
+            })
+            should_not contain_package('myphp-cli')
+            should_not contain_package('myphp-dev')
             should_not contain_package('php-pear')
           }
         end


### PR DESCRIPTION
set as parameter to init.pp to some non-default

Also spec for xml package
add spec test for package_prefix

I'm in the phase of updating the php module, to get the
better php 7 support. Some of the boxes run on Ubuntu.
They have php 5.5 installed, and I don't want to upgrade
just because of the puppet php module update ;)

So besides other parameters, I set the package_prefix to 'php5-'
The only package that doesn't seem to catch that up is the php-xml
package, enforced via the php::dev class.

This PR also lets the xml package pick the right prefix, as well
as adding a bunch of spec tests, for ensuring correct functionality.


