### PR TITLE
Allow to specify a fpm_service_provider,

### DIFF
--- a/manifests/fpm.pp
+++ b/manifests/fpm.pp
@@ -12,6 +12,11 @@
 #   This is the name of the php-fpm service. It defaults to reasonable OS
 #   defaults but can be different in case of using php7.0/other OS/custom fpm service
 #
+#   [*service_provider*]
+#   This is the name of the service provider, in case there is a non
+#   OS default service provider used to start FPM.
+#   Defaults to 'undef', pick system defaults.
+#
 # [*pools*]
 #   Hash of php::fpm::pool resources that will be created. Defaults
 #   to a single php::fpm::pool named www with default parameters.
@@ -43,6 +48,7 @@ class php::fpm (
   $service_ensure       = $::php::params::fpm_service_ensure,
   $service_enable       = $::php::params::fpm_service_enable,
   $service_name         = $::php::params::fpm_service_name,
+  $service_provider     = undef,
   $package              = "${::php::package_prefix}${::php::params::fpm_package_suffix}",
   $inifile              = $::php::params::fpm_inifile,
   $settings             = {},
@@ -86,6 +92,7 @@ class php::fpm (
       ensure       => $service_ensure,
       enable       => $service_enable,
       service_name => $service_name,
+      provider     => $service_provider,
     } ->
   anchor { '::php::fpm::end': }
 

--- a/manifests/fpm/service.pp
+++ b/manifests/fpm/service.pp
@@ -11,10 +11,14 @@
 # [*enable*]
 #   Defines if the service is enabled
 #
+# [*provider*]
+#   Defines if the service provider to use
+#
 class php::fpm::service(
   $service_name = $::php::params::fpm_service_name,
   $ensure       = $::php::params::fpm_service_ensure,
   $enable       = $::php::params::fpm_service_enable,
+  $provider     = undef,
 ) inherits ::php::params {
 
   if $caller_module_name != $module_name {
@@ -34,6 +38,7 @@ class php::fpm::service(
   service { $service_name:
     ensure     => $ensure,
     enable     => $enable,
+    provider   => $provider,
     hasrestart => true,
     restart    => $restart,
     hasstatus  => true,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,6 +23,11 @@
 #   This is the name of the php-fpm service. It defaults to reasonable OS
 #   defaults but can be different in case of using php7.0/other OS/custom fpm service
 #
+#   [*fpm_service_provider*]
+#   This is the name of the service provider, in case there is a non
+#   OS default service provider used to start FPM.
+#   Defaults to 'undef', pick system defaults.
+#
 # [*dev*]
 #   Install php header files, needed to install pecl modules
 #
@@ -75,27 +80,28 @@
 # [*settings*]
 #
 class php (
-  $ensure             = $::php::params::ensure,
-  $manage_repos       = $::php::params::manage_repos,
-  $fpm                = true,
-  $fpm_service_enable = $::php::params::fpm_service_enable,
-  $fpm_service_ensure = $::php::params::fpm_service_ensure,
-  $fpm_service_name   = $::php::params::fpm_service_name,
-  $embedded           = false,
-  $dev                = true,
-  $composer           = true,
-  $pear               = true,
-  $pear_ensure        = $::php::params::pear_ensure,
-  $phpunit            = false,
-  $extensions         = {},
-  $settings           = {},
-  $package_prefix     = $::php::params::package_prefix,
-  $config_root_ini    = $::php::params::config_root_ini,
-  $ext_tool_enable    = $::php::params::ext_tool_enable,
-  $ext_tool_query     = $::php::params::ext_tool_query,
-  $ext_tool_enabled   = $::php::params::ext_tool_enabled,
-  $log_owner          = $::php::params::fpm_user,
-  $log_group          = $::php::params::fpm_group,
+  $ensure               = $::php::params::ensure,
+  $manage_repos         = $::php::params::manage_repos,
+  $fpm                  = true,
+  $fpm_service_enable   = $::php::params::fpm_service_enable,
+  $fpm_service_ensure   = $::php::params::fpm_service_ensure,
+  $fpm_service_name     = $::php::params::fpm_service_name,
+  $fpm_service_provider = undef,
+  $embedded             = false,
+  $dev                  = true,
+  $composer             = true,
+  $pear                 = true,
+  $pear_ensure          = $::php::params::pear_ensure,
+  $phpunit              = false,
+  $extensions           = {},
+  $settings             = {},
+  $package_prefix       = $::php::params::package_prefix,
+  $config_root_ini      = $::php::params::config_root_ini,
+  $ext_tool_enable      = $::php::params::ext_tool_enable,
+  $ext_tool_query       = $::php::params::ext_tool_query,
+  $ext_tool_enabled     = $::php::params::ext_tool_enabled,
+  $log_owner            = $::php::params::fpm_user,
+  $log_group            = $::php::params::fpm_group,
 ) inherits ::php::params {
 
   validate_string($ensure)
@@ -153,12 +159,13 @@ class php (
   if $fpm {
     Anchor['php::begin'] ->
       class { '::php::fpm':
-        service_enable => $fpm_service_enable,
-        service_ensure => $fpm_service_ensure,
-        service_name   => $fpm_service_name,
-        settings       => $real_settings,
-        log_owner      => $log_owner,
-        log_group      => $log_group,
+        service_enable   => $fpm_service_enable,
+        service_ensure   => $fpm_service_ensure,
+        service_name     => $fpm_service_name,
+        service_provider => $fpm_service_provider,
+        settings         => $real_settings,
+        log_owner        => $log_owner,
+        log_group        => $log_group,
       } ->
     Anchor['php::end']
   }


### PR DESCRIPTION
 to allow using non-default service provider for fpm.

I'm on ubuntu 14.04, where the fpm service provider
picks init as default, but it should use upstart.

The default for the service_provider are all set to 
undef, so it picks whatever is default, as it currently
is, only allows the user to override to whatever provider
he wants to use.