### PR TITLE
fix trusty default php5-fpm / php5enmod name, disable xml dependency

### DIFF
--- a/manifests/dev.pp
+++ b/manifests/dev.pp
@@ -26,7 +26,7 @@ class php::dev(
     default   => $package,
   }
 
-  if $::operatingsystem == 'Ubuntu' {
+  if ($::operatingsystem == 'Ubuntu') and ($::php::globals::php_version != '5.5') {
     ensure_packages(["${php::package_prefix}xml"], {
       ensure  => present,
       require => Class['::apt::update'],

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -57,9 +57,9 @@ class php::globals (
             $default_config_root  = "/etc/php/${globals_php_version}"
             $default_fpm_pid_file = "/var/run/php/php${globals_php_version}-fpm.pid"
             $fpm_error_log        = "/var/log/php${globals_php_version}-fpm.log"
-            $fpm_service_name     = "php${globals_php_version}-fpm"
-            $ext_tool_enable      = "/usr/sbin/phpenmod -v ${globals_php_version}"
-            $ext_tool_query       = "/usr/sbin/phpquery -v ${globals_php_version}"
+            $fpm_service_name     = 'php5-fpm'
+            $ext_tool_enable      = '/usr/sbin/php5enmod'
+            $ext_tool_query       = '/usr/sbin/php5query'
             $package_prefix       = 'php5.5-'
           }
           /^5\.6/: {

--- a/manifests/pear.pp
+++ b/manifests/pear.pp
@@ -43,7 +43,7 @@ class php::pear (
   validate_string($ensure)
   validate_string($package_name)
 
-  if $::operatingsystem == 'Ubuntu' {
+  if ($::operatingsystem == 'Ubuntu') and ($::php::globals::php_version != '5.5') {
     ensure_packages(["${php::package_prefix}xml"], {
       ensure  => present,
       require => Class['::apt::update'],


### PR DESCRIPTION
this fixes fpm service name on Ubuntu Trusty 14.04 as there using default version. 